### PR TITLE
fix: Fix type enum in the yaml

### DIFF
--- a/core/src/main/resources/api/rest.yaml
+++ b/core/src/main/resources/api/rest.yaml
@@ -199,7 +199,7 @@ components:
           example: c533b987-2cfa-4033-8717-665e680df6f3
         type:
           type: string
-          enum: [ document, spreadsheet, presentation ]
+          enum: [ DOCUMENT, SPREADSHEET, PRESENTATION ]
           description: "Docs file type: it can be DOCUMENT, SPREADSHEET or PRESENTATION"
           example: DOCUMENT
 


### PR DESCRIPTION
Values of the `type` enum is uppercase, so the generated code is compliant with the guide lines