### PR TITLE
fix: DOCS-167 Remove access token from the returned wopi endpoint

### DIFF
--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -85,7 +85,7 @@ SPDX-License-Identifier: AGPL-3.0-only
       </exclusions>
       <groupId>com.zextras.carbonio.docs-connector</groupId>
 
-      <version>0.0.2</version>
+      <version>0.0.3</version>
     </dependency>
 
     <!-- Jetty dependencies -->
@@ -135,7 +135,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-docs-connector-ce</artifactId>
     <groupId>com.zextras.carbonio.docs-connector</groupId>
-    <version>0.0.2</version>
+    <version>0.0.3</version>
   </parent>
 
   <properties>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -40,7 +40,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     <dependency>
       <artifactId>carbonio-docs-connector-ce-generated</artifactId>
       <groupId>com.zextras.carbonio.docs-connector</groupId>
-      <version>0.0.2</version>
+      <version>0.0.3</version>
     </dependency>
 
     <dependency>
@@ -130,7 +130,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-docs-connector-ce</artifactId>
     <groupId>com.zextras.carbonio.docs-connector</groupId>
-    <version>0.0.2</version>
+    <version>0.0.3</version>
   </parent>
 
   <properties>

--- a/core/src/main/java/com/zextras/carbonio/docs_connector/services/FilesService.java
+++ b/core/src/main/java/com/zextras/carbonio/docs_connector/services/FilesService.java
@@ -52,17 +52,11 @@ public class FilesService {
 
             // WopiSRC
             StringBuilder wopiEndpointBuilder = new StringBuilder()
-              .append("http://127.78.0.13:10000/wopi/")
+              .append("http://127.78.0.12:20000/wopi/")
               .append(nodeId);
 
             optVersion
-              .map(version -> wopiEndpointBuilder.append("?version=").append(version).append("&"))
-              .orElseGet(() -> wopiEndpointBuilder.append("?"));
-
-            // The & or ? connector is appended before
-            wopiEndpointBuilder
-              .append("access_token=")
-              .append(token.getTokenId());
+              .map(version -> wopiEndpointBuilder.append("?version=").append(version));
 
             // Public URL
             StringBuilder publicURLBuilder = new StringBuilder()

--- a/generated/pom.xml
+++ b/generated/pom.xml
@@ -82,12 +82,12 @@
   <parent>
     <artifactId>carbonio-docs-connector-ce</artifactId>
     <groupId>com.zextras.carbonio.docs-connector</groupId>
-    <version>0.0.2</version>
+    <version>0.0.3</version>
   </parent>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
-  <version>0.0.2</version>
+  <version>0.0.3</version>
 </project>

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -4,7 +4,7 @@ targets=(
 )
 pkgname="carbonio-docs-connector-ce"
 pkgver="0.0.3"
-pkgrel="1"
+pkgrel="2"
 pkgdesc="Carbonio docs connector"
 pkgdesclong=(
   "Carbonio docs connector"

--- a/pom.xml
+++ b/pom.xml
@@ -240,5 +240,5 @@ SPDX-License-Identifier: AGPL-3.0-only
     </repository>
   </repositories>
 
-  <version>0.0.2</version>
+  <version>0.0.3</version>
 </project>


### PR DESCRIPTION
When docs-editor cleans up its environment from the last session in order
to reopen a document already opened before, the comunication with
carbonio-docs-connector fails sistematically due to an invalid token used
to call the API.

Now the access_token is returned only in the url used to redirect the openFile
request to the carbonio-docs-editor and it has been removed from the wopi
endpoint. When the carbonio-docs-editor cleans up the environment it makes
the request to carbonio-docs-connector passing the token formed correctly.