### PR TITLE
build(deps): update all dependencies/plugins and migrate javax->jakarta

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,15 +37,15 @@ repos:
         stages: [commit-msg]
         args: []
 
-  #- repo: https://github.com/fsfe/reuse-tool
-  #  rev: v3.0.1
-  #  hooks:
-  #    - id: reuse
+  - repo: https://github.com/fsfe/reuse-tool
+    rev: v3.0.1
+    hooks:
+      - id: reuse
 
-  #- repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
-  #  rev: v2.12.0
-  #  hooks:
-  #    - id: pretty-format-java
+  - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
+    rev: v2.12.0
+    hooks:
+      - id: pretty-format-java
 
   - repo: https://github.com/ejba/pre-commit-maven
     rev: v0.3.4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,23 +37,15 @@ repos:
         stages: [commit-msg]
         args: []
 
-  - repo: https://github.com/fsfe/reuse-tool
-    rev: v3.0.1
-    hooks:
-      - id: reuse
+  #- repo: https://github.com/fsfe/reuse-tool
+  #  rev: v3.0.1
+  #  hooks:
+  #    - id: reuse
 
-  - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
-    rev: v2.12.0
-    hooks:
-      - id: pretty-format-java
-
-  - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.39.0
-    hooks:
-      - id: markdownlint
-        language_version: 16.0.0
-      - id: markdownlint-fix
-        language_version: 16.0.0
+  #- repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
+  #  rev: v2.12.0
+  #  hooks:
+  #    - id: pretty-format-java
 
   - repo: https://github.com/ejba/pre-commit-maven
     rev: v0.3.4

--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -60,7 +60,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
     <!-- RestEasy dependencies -->
     <dependency>
-      <groupId>org.jboss.resteasy</groupId>
+      <groupId>com.federicorispo</groupId>
       <artifactId>resteasy-guice</artifactId>
     </dependency>
 

--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -125,7 +125,7 @@ SPDX-License-Identifier: AGPL-3.0-only
                 </transformer>
                 <transformer
                   implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
-                  <resource>META-INF/services/javax.ws.rs.ext.Providers</resource>
+                  <resource>META-INF/services/jakarta.ws.rs.ext.Providers</resource>
                 </transformer>
               </transformers>
             </configuration>

--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -54,8 +54,8 @@ SPDX-License-Identifier: AGPL-3.0-only
     </dependency>
 
     <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-servlet</artifactId>
+      <groupId>org.eclipse.jetty.ee10</groupId>
+      <artifactId>jetty-ee10-servlet</artifactId>
     </dependency>
 
     <!-- RestEasy dependencies -->

--- a/boot/src/main/java/com/zextras/carbonio/docs_connector/Boot.java
+++ b/boot/src/main/java/com/zextras/carbonio/docs_connector/Boot.java
@@ -9,8 +9,8 @@ import com.zextras.carbonio.docs_connector.config.DocsConnectorModule;
 import java.net.InetSocketAddress;
 import java.util.Optional;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.servlet.ServletContextHandler;
-import org.eclipse.jetty.servlet.ServletHolder;
+import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee10.servlet.ServletHolder;
 import org.jboss.resteasy.plugins.guice.GuiceResteasyBootstrapServletContextListener;
 import org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher;
 import org.slf4j.LoggerFactory;
@@ -37,7 +37,7 @@ public class Boot {
 
     try {
       server = new Server(InetSocketAddress.createUnresolved(Service.IP, Service.PORT));
-      ServletContextHandler servletHandler = new ServletContextHandler(server, "/");
+      ServletContextHandler servletHandler = new ServletContextHandler("/", ServletContextHandler.SESSIONS);
       servletHandler.addEventListener(injector.getInstance(
         GuiceResteasyBootstrapServletContextListener.class)
       );

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -40,7 +40,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     </dependency>
 
     <dependency>
-      <groupId>org.jboss.resteasy</groupId>
+      <groupId>com.federicorispo</groupId>
       <artifactId>resteasy-guice</artifactId>
     </dependency>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -55,20 +55,10 @@ SPDX-License-Identifier: AGPL-3.0-only
       <artifactId>jakarta.servlet-api</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>jakarta.enterprise</groupId>
-      <artifactId>jakarta.enterprise.cdi-api</artifactId>
-    </dependency>
-
     <!-- RestEasy dependencies -->
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-jackson2-provider</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.jboss.resteasy</groupId>
-      <artifactId>resteasy-multipart-provider</artifactId>
     </dependency>
 
     <!-- Jackson dependencies -->

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -55,6 +55,11 @@ SPDX-License-Identifier: AGPL-3.0-only
       <artifactId>jakarta.servlet-api</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>jakarta.enterprise</groupId>
+      <artifactId>jakarta.enterprise.cdi-api</artifactId>
+    </dependency>
+
     <!-- RestEasy dependencies -->
     <dependency>
       <groupId>org.jboss.resteasy</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -50,11 +50,9 @@ SPDX-License-Identifier: AGPL-3.0-only
       <artifactId>logback-classic</artifactId>
     </dependency>
 
-    <!-- JavaEE API -->
     <dependency>
-      <groupId>javax</groupId>
-      <artifactId>javaee-api</artifactId>
-      <scope>provided</scope>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
     </dependency>
 
     <!-- RestEasy dependencies -->
@@ -146,8 +144,8 @@ SPDX-License-Identifier: AGPL-3.0-only
     </dependency>
 
     <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-servlet</artifactId>
+      <groupId>org.eclipse.jetty.ee10</groupId>
+      <artifactId>jetty-ee10-servlet</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/core/src/main/java/com/zextras/carbonio/docs_connector/auth/AccessTokenValidationFilter.java
+++ b/core/src/main/java/com/zextras/carbonio/docs_connector/auth/AccessTokenValidationFilter.java
@@ -10,12 +10,12 @@ import com.zextras.carbonio.docs_connector.dal.repositories.interfaces.OpenDocum
 import java.time.Clock;
 import java.util.List;
 import java.util.UUID;
-import javax.ws.rs.container.ContainerRequestContext;
-import javax.ws.rs.container.ContainerRequestFilter;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
-import javax.ws.rs.ext.Provider;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+import jakarta.ws.rs.ext.Provider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/core/src/main/java/com/zextras/carbonio/docs_connector/auth/CookieAuthenticationFilter.java
+++ b/core/src/main/java/com/zextras/carbonio/docs_connector/auth/CookieAuthenticationFilter.java
@@ -8,12 +8,12 @@ import com.zextras.carbonio.docs_connector.Constants.Context;
 import com.zextras.carbonio.docs_connector.Constants.Service.API.Endpoints;
 import com.zextras.carbonio.usermanagement.UserManagementClient;
 import java.util.Optional;
-import javax.ws.rs.container.ContainerRequestContext;
-import javax.ws.rs.container.ContainerRequestFilter;
-import javax.ws.rs.core.Cookie;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
-import javax.ws.rs.ext.Provider;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.core.Cookie;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+import jakarta.ws.rs.ext.Provider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/core/src/main/java/com/zextras/carbonio/docs_connector/config/RestApplication.java
+++ b/core/src/main/java/com/zextras/carbonio/docs_connector/config/RestApplication.java
@@ -1,7 +1,7 @@
 package com.zextras.carbonio.docs_connector.config;
 
-import javax.ws.rs.ApplicationPath;
-import javax.ws.rs.core.Application;
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
 
 @ApplicationPath("/services/docs")
 public class RestApplication extends Application {

--- a/core/src/main/java/com/zextras/carbonio/docs_connector/controllers/FilesController.java
+++ b/core/src/main/java/com/zextras/carbonio/docs_connector/controllers/FilesController.java
@@ -2,17 +2,17 @@ package com.zextras.carbonio.docs_connector.controllers;
 
 import com.zextras.carbonio.docs_connector.types.InsertFile;
 import java.util.UUID;
-import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.HeaderParam;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import org.jboss.resteasy.annotations.jaxrs.QueryParam;
 
 @Path("/files")

--- a/core/src/main/java/com/zextras/carbonio/docs_connector/controllers/WopiController.java
+++ b/core/src/main/java/com/zextras/carbonio/docs_connector/controllers/WopiController.java
@@ -2,18 +2,18 @@ package com.zextras.carbonio.docs_connector.controllers;
 
 import java.io.InputStream;
 import java.util.UUID;
-import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.HeaderParam;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 
 @Path("/wopi/{nodeId}")
 public interface WopiController {

--- a/core/src/main/java/com/zextras/carbonio/docs_connector/controllers/impl/FilesControllerImpl.java
+++ b/core/src/main/java/com/zextras/carbonio/docs_connector/controllers/impl/FilesControllerImpl.java
@@ -1,6 +1,5 @@
 package com.zextras.carbonio.docs_connector.controllers.impl;
 
-import com.google.inject.Inject;
 import com.zextras.carbonio.docs_connector.Constants.Context;
 import com.zextras.carbonio.docs_connector.controllers.FilesController;
 import com.zextras.carbonio.docs_connector.services.FilesService;
@@ -9,9 +8,11 @@ import java.net.URI;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.UUID;
+
+import jakarta.inject.Inject;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.ws.rs.core.Response;
-import org.jboss.resteasy.plugins.guice.RequestScoped;
+import jakarta.enterprise.context.RequestScoped;
 
 @RequestScoped
 public class FilesControllerImpl implements FilesController {

--- a/core/src/main/java/com/zextras/carbonio/docs_connector/controllers/impl/FilesControllerImpl.java
+++ b/core/src/main/java/com/zextras/carbonio/docs_connector/controllers/impl/FilesControllerImpl.java
@@ -9,9 +9,9 @@ import java.net.URI;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.UUID;
-import javax.enterprise.context.RequestScoped;
-import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.core.Response;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.core.Response;
+import org.jboss.resteasy.plugins.guice.RequestScoped;
 
 @RequestScoped
 public class FilesControllerImpl implements FilesController {

--- a/core/src/main/java/com/zextras/carbonio/docs_connector/controllers/impl/FilesControllerImpl.java
+++ b/core/src/main/java/com/zextras/carbonio/docs_connector/controllers/impl/FilesControllerImpl.java
@@ -12,9 +12,7 @@ import java.util.UUID;
 import jakarta.inject.Inject;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.ws.rs.core.Response;
-import jakarta.enterprise.context.RequestScoped;
 
-@RequestScoped
 public class FilesControllerImpl implements FilesController {
 
   private final FilesService filesService;

--- a/core/src/main/java/com/zextras/carbonio/docs_connector/controllers/impl/WopiControllerImpl.java
+++ b/core/src/main/java/com/zextras/carbonio/docs_connector/controllers/impl/WopiControllerImpl.java
@@ -8,12 +8,12 @@ import com.zextras.carbonio.docs_connector.services.WopiService;
 import java.io.InputStream;
 import java.util.Optional;
 import java.util.UUID;
-import javax.enterprise.context.RequestScoped;
-import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+import org.jboss.resteasy.plugins.guice.RequestScoped;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/core/src/main/java/com/zextras/carbonio/docs_connector/controllers/impl/WopiControllerImpl.java
+++ b/core/src/main/java/com/zextras/carbonio/docs_connector/controllers/impl/WopiControllerImpl.java
@@ -14,11 +14,9 @@ import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
-import jakarta.enterprise.context.RequestScoped;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@RequestScoped
 public class WopiControllerImpl implements WopiController {
 
   private static final Logger logger = LoggerFactory.getLogger(WopiController.class);

--- a/core/src/main/java/com/zextras/carbonio/docs_connector/controllers/impl/WopiControllerImpl.java
+++ b/core/src/main/java/com/zextras/carbonio/docs_connector/controllers/impl/WopiControllerImpl.java
@@ -1,6 +1,5 @@
 package com.zextras.carbonio.docs_connector.controllers.impl;
 
-import com.google.inject.Inject;
 import com.zextras.carbonio.docs_connector.Constants.Context;
 import com.zextras.carbonio.docs_connector.controllers.WopiController;
 import com.zextras.carbonio.docs_connector.dal.dao.OpenDocumentToken;
@@ -8,12 +7,14 @@ import com.zextras.carbonio.docs_connector.services.WopiService;
 import java.io.InputStream;
 import java.util.Optional;
 import java.util.UUID;
+
+import jakarta.inject.Inject;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
-import org.jboss.resteasy.plugins.guice.RequestScoped;
+import jakarta.enterprise.context.RequestScoped;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/core/src/main/java/com/zextras/carbonio/docs_connector/types/InsertFile.java
+++ b/core/src/main/java/com/zextras/carbonio/docs_connector/types/InsertFile.java
@@ -1,6 +1,6 @@
 package com.zextras.carbonio.docs_connector.types;
 
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 
 public class InsertFile {
 

--- a/core/src/test/java-it/com/zextras/carbonio/docs_connector/apis/Simulator.java
+++ b/core/src/test/java-it/com/zextras/carbonio/docs_connector/apis/Simulator.java
@@ -8,8 +8,8 @@ import com.zextras.carbonio.docs_connector.config.DocsConnectorModule;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.server.LocalConnector;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.servlet.ServletContextHandler;
-import org.eclipse.jetty.servlet.ServletHolder;
+import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee10.servlet.ServletHolder;
 import org.jboss.resteasy.plugins.guice.GuiceResteasyBootstrapServletContextListener;
 import org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher;
 import org.mockserver.client.MockServerClient;
@@ -71,7 +71,7 @@ public class Simulator implements AutoCloseable {
       httpLocalConnector = new LocalConnector(jettyServer);
       jettyServer.addConnector(httpLocalConnector);
 
-      ServletContextHandler servletContextHandler = new ServletContextHandler(jettyServer, "/");
+      ServletContextHandler servletContextHandler = new ServletContextHandler("/", ServletContextHandler.SESSIONS);
       ServletHolder servletHolder = new ServletHolder(HttpServletDispatcher.class);
 
       servletContextHandler.addEventListener(injector.getInstance(

--- a/pom.xml
+++ b/pom.xml
@@ -33,28 +33,28 @@ SPDX-License-Identifier: AGPL-3.0-only
   </modules>
 
   <properties>
-    <assertj.version>3.24.2</assertj.version>
-    <caffeine.version>3.1.6</caffeine.version>
+    <assertj.version>3.25.3</assertj.version>
+    <caffeine.version>3.1.8</caffeine.version>
     <carbonio-user-management-sdk.version>0.3.0</carbonio-user-management-sdk.version>
     <carbonio-files-sdk.version>0.0.3</carbonio-files-sdk.version>
-    <guice.version>6.0.0</guice.version>
-    <jackson.version>2.15.2</jackson.version>
+    <guice.version>7.0.0</guice.version>
+    <jackson.version>2.17.0</jackson.version>
     <javaee-api.version>8.0.1</javaee-api.version>
-    <jetty.version>10.0.15</jetty.version>
+    <jetty.version>11.0.20</jetty.version>
     <jsonassert.version>1.5.1</jsonassert.version>
-    <junit5.version>5.9.2</junit5.version>
-    <logback-classic.version>1.3.6</logback-classic.version>
+    <junit5.version>5.10.2</junit5.version>
+    <logback-classic.version>1.5.3</logback-classic.version>
     <mock-server.version>5.15.0</mock-server.version>
-    <mockito.version>5.2.0</mockito.version>
+    <mockito.version>5.11.0</mockito.version>
     <resteasy.version>4.7.9.Final</resteasy.version>
-    <swagger-core-version>1.6.11</swagger-core-version>
+    <swagger-core-version>2.2.21</swagger-core-version>
 
     <!-- Plugins -->
-    <build-helper-maven.version>3.4.0</build-helper-maven.version>
-    <maven-compiler.version>3.11.0</maven-compiler.version>
-    <maven-shade.version>3.5.0</maven-shade.version>
-    <maven-failsafe.version>3.1.2</maven-failsafe.version>
-    <maven-jacoco.version>0.8.10</maven-jacoco.version>
+    <build-helper-maven.version>3.5.0</build-helper-maven.version>
+    <maven-compiler.version>3.13.0</maven-compiler.version>
+    <maven-shade.version>3.5.2</maven-shade.version>
+    <maven-failsafe.version>3.2.5</maven-failsafe.version>
+    <maven-jacoco.version>0.8.11</maven-jacoco.version>
     <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
     <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
     <maven-surfire.version>3.1.2</maven-surfire.version>

--- a/pom.xml
+++ b/pom.xml
@@ -39,8 +39,8 @@ SPDX-License-Identifier: AGPL-3.0-only
     <carbonio-files-sdk.version>0.0.3</carbonio-files-sdk.version>
     <guice.version>7.0.0</guice.version>
     <jackson.version>2.17.0</jackson.version>
-    <javaee-api.version>8.0.1</javaee-api.version>
-    <jetty.version>11.0.20</jetty.version>
+    <jakarta-servlet-api.version>6.0.0</jakarta-servlet-api.version>
+    <jetty.version>12.0.7</jetty.version>
     <jsonassert.version>1.5.1</jsonassert.version>
     <junit5.version>5.10.2</junit5.version>
     <logback-classic.version>1.5.3</logback-classic.version>
@@ -107,17 +107,15 @@ SPDX-License-Identifier: AGPL-3.0-only
       </dependency>
 
       <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-servlet</artifactId>
+        <groupId>org.eclipse.jetty.ee10</groupId>
+        <artifactId>jetty-ee10-servlet</artifactId>
         <version>${jetty.version}</version>
       </dependency>
 
-      <!-- JavaEE API -->
       <dependency>
-        <groupId>javax</groupId>
-        <artifactId>javaee-api</artifactId>
-        <version>${javaee-api.version}</version>
-        <scope>provided</scope>
+        <groupId>jakarta.servlet</groupId>
+        <artifactId>jakarta.servlet-api</artifactId>
+        <version>${jakarta-servlet-api.version}</version>
       </dependency>
 
       <!-- RestEasy dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,8 @@ SPDX-License-Identifier: AGPL-3.0-only
     <logback-classic.version>1.5.3</logback-classic.version>
     <mock-server.version>5.15.0</mock-server.version>
     <mockito.version>5.11.0</mockito.version>
-    <resteasy.version>4.7.9.Final</resteasy.version>
+    <resteasy.version>6.2.7.Final</resteasy.version>
+    <resteasy-guice.version>6.2.7-alpha</resteasy-guice.version>
     <swagger-core-version>2.2.21</swagger-core-version>
 
     <!-- Plugins -->
@@ -87,9 +88,9 @@ SPDX-License-Identifier: AGPL-3.0-only
       </dependency>
 
       <dependency>
-        <groupId>org.jboss.resteasy</groupId>
+        <groupId>com.federicorispo</groupId>
         <artifactId>resteasy-guice</artifactId>
-        <version>${resteasy.version}</version>
+        <version>${resteasy-guice.version}</version>
       </dependency>
 
       <!-- Logging -->

--- a/pom.xml
+++ b/pom.xml
@@ -120,12 +120,6 @@ SPDX-License-Identifier: AGPL-3.0-only
         <version>${jakarta-servlet-api.version}</version>
       </dependency>
 
-      <dependency>
-        <groupId>jakarta.enterprise</groupId>
-        <artifactId>jakarta.enterprise.cdi-api</artifactId>
-        <version>${jakarta-enterprise.version}</version>
-      </dependency>
-
       <!-- RestEasy dependencies -->
       <dependency>
         <groupId>org.jboss.resteasy</groupId>
@@ -136,12 +130,6 @@ SPDX-License-Identifier: AGPL-3.0-only
       <dependency>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-servlet-initializer</artifactId>
-        <version>${resteasy.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.jboss.resteasy</groupId>
-        <artifactId>resteasy-multipart-provider</artifactId>
         <version>${resteasy.version}</version>
       </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     <guice.version>7.0.0</guice.version>
     <jackson.version>2.17.0</jackson.version>
     <jakarta-servlet-api.version>6.0.0</jakarta-servlet-api.version>
+    <jakarta-enterprise.version>4.1.0.RC1</jakarta-enterprise.version>
     <jetty.version>12.0.7</jetty.version>
     <jsonassert.version>1.5.1</jsonassert.version>
     <junit5.version>5.10.2</junit5.version>
@@ -117,6 +118,12 @@ SPDX-License-Identifier: AGPL-3.0-only
         <groupId>jakarta.servlet</groupId>
         <artifactId>jakarta.servlet-api</artifactId>
         <version>${jakarta-servlet-api.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>jakarta.enterprise</groupId>
+        <artifactId>jakarta.enterprise.cdi-api</artifactId>
+        <version>${jakarta-enterprise.version}</version>
       </dependency>
 
       <!-- RestEasy dependencies -->


### PR DESCRIPTION
All dependencies are updated to their last version:

- assertj: 3.24.2 -> 3.25.3
- caffeine: 3.1.6 -> 3.1.8
- guice: 6.0.0 -> 7.0.0
- jackson: 2.15.2 -> 2.17.0
- jetty: 10.0.15 -> 12.0.7
- junit5: 5.9.2 -> 5.10.2
- logback-classic: 1.3.6 -> 1.5.3
- mockito: 5.2.0 -> 5.11.0
- resteasy: 4.7.9.Final -> 6.2.7.Final
- swagger-core: 1.6.11 -> 2.2.21

Refs: DOCS-207