### PR TITLE
feat: add health check APIs

### DIFF
--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -25,7 +25,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <groupId>com.zextras.carbonio.docs-connector</groupId>
     <artifactId>carbonio-docs-connector-ce</artifactId>
-    <version>0.3.3-1</version>
+    <version>0.4.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -25,7 +25,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <groupId>com.zextras.carbonio.docs-connector</groupId>
     <artifactId>carbonio-docs-connector-ce</artifactId>
-    <version>0.3.3-1</version>
+    <version>0.4.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/core/src/main/java/com/zextras/carbonio/docs_connector/config/DocsConnectorModule.java
+++ b/core/src/main/java/com/zextras/carbonio/docs_connector/config/DocsConnectorModule.java
@@ -7,8 +7,10 @@ import com.zextras.carbonio.docs_connector.Constants.Config.UserService;
 import com.zextras.carbonio.docs_connector.auth.AccessTokenValidationFilter;
 import com.zextras.carbonio.docs_connector.auth.CookieAuthenticationFilter;
 import com.zextras.carbonio.docs_connector.controllers.FilesController;
+import com.zextras.carbonio.docs_connector.controllers.HealthController;
 import com.zextras.carbonio.docs_connector.controllers.WopiController;
 import com.zextras.carbonio.docs_connector.controllers.impl.FilesControllerImpl;
+import com.zextras.carbonio.docs_connector.controllers.impl.HealthControllerImpl;
 import com.zextras.carbonio.docs_connector.controllers.impl.WopiControllerImpl;
 import com.zextras.carbonio.docs_connector.dal.repositories.impl.OpenDocumentTokenRepositoryInMemory;
 import com.zextras.carbonio.docs_connector.dal.repositories.interfaces.OpenDocumentTokenRepository;
@@ -21,6 +23,7 @@ public class DocsConnectorModule extends RequestScopeModule {
 
   @Override
   public void configure() {
+    bind(HealthController.class).to(HealthControllerImpl.class);
     bind(FilesController.class).to(FilesControllerImpl.class);
     bind(WopiController.class).to(WopiControllerImpl.class);
 

--- a/core/src/main/java/com/zextras/carbonio/docs_connector/controllers/HealthController.java
+++ b/core/src/main/java/com/zextras/carbonio/docs_connector/controllers/HealthController.java
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.docs_connector.controllers;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+@Path("/health")
+public interface HealthController {
+
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  Response health();
+
+  @GET
+  @Path("ready")
+  Response healthReady();
+
+  @GET
+  @Path("live")
+  Response healthLive();
+}

--- a/core/src/main/java/com/zextras/carbonio/docs_connector/controllers/impl/HealthControllerImpl.java
+++ b/core/src/main/java/com/zextras/carbonio/docs_connector/controllers/impl/HealthControllerImpl.java
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.docs_connector.controllers.impl;
+
+import com.google.inject.Inject;
+import com.zextras.carbonio.docs_connector.controllers.HealthController;
+import com.zextras.carbonio.docs_connector.services.HealthService;
+import com.zextras.carbonio.docs_connector.types.health.HealthStatus;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class HealthControllerImpl implements HealthController {
+
+  private static final Logger logger = LoggerFactory.getLogger(HealthControllerImpl.class);
+
+  private final HealthService healthService;
+
+  @Inject
+  public HealthControllerImpl(HealthService healthService) {
+    this.healthService = healthService;
+  }
+
+  public Response health() {
+    HealthStatus serviceHealthStatus = healthService.getServiceHealthStatus();
+
+    return serviceHealthStatus.isReady()
+        ? Response.ok().entity(serviceHealthStatus).build()
+        : Response.status(Status.BAD_GATEWAY).entity(serviceHealthStatus).build();
+  }
+
+  /**
+   * @return a {@link Response#noContent()} representing the liveness of the service
+   */
+  public Response healthLive() {
+    logger.debug("carbonio-docs-connector is live");
+
+    return Response.noContent().build();
+  }
+
+  public Response healthReady() {
+    boolean dependenciesAreReady = healthService.areServiceDependenciesReady();
+
+    return dependenciesAreReady
+        ? Response.noContent().build()
+        : Response.status(Status.BAD_GATEWAY).build();
+  }
+}

--- a/core/src/main/java/com/zextras/carbonio/docs_connector/services/HealthService.java
+++ b/core/src/main/java/com/zextras/carbonio/docs_connector/services/HealthService.java
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.docs_connector.services;
+
+import com.google.inject.Inject;
+import com.zextras.carbonio.docs_connector.types.health.DependencyType;
+import com.zextras.carbonio.docs_connector.types.health.HealthStatus;
+import com.zextras.carbonio.docs_connector.types.health.ServiceHealth;
+import com.zextras.carbonio.files.FilesClient;
+import com.zextras.carbonio.usermanagement.UserManagementClient;
+import java.util.ArrayList;
+import java.util.List;
+
+public class HealthService {
+
+  private final UserManagementClient userManagementClient;
+  private final FilesClient filesClient;
+
+  @Inject
+  public HealthService(UserManagementClient userManagementClient, FilesClient filesClient) {
+    this.userManagementClient = userManagementClient;
+    this.filesClient = filesClient;
+  }
+
+  public boolean areServiceDependenciesReady() {
+    return userManagementClient.healthCheck();
+  }
+
+  public HealthStatus getServiceHealthStatus() {
+    List<ServiceHealth> dependencies = new ArrayList<>();
+    dependencies.add(getUserManagementHealth());
+    dependencies.add(getFilesHealth());
+
+    boolean docsConnectorIsReady =
+        dependencies.stream()
+            .filter(dependency -> DependencyType.REQUIRED.equals(dependency.getType()))
+            .allMatch(ServiceHealth::isReady);
+
+    return new HealthStatus().setReady(docsConnectorIsReady).setDependencies(dependencies);
+  }
+
+  public ServiceHealth getUserManagementHealth() {
+    boolean userManagementIsLive = userManagementClient.healthCheck();
+
+    return new ServiceHealth()
+        .setName("carbonio-user-management")
+        .setType(DependencyType.REQUIRED)
+        .setLive(userManagementIsLive)
+        .setReady(userManagementIsLive);
+  }
+
+  public ServiceHealth getFilesHealth() {
+    boolean filesIsLive = filesClient.healthCheck();
+
+    return new ServiceHealth()
+      .setName("carbonio-files")
+      .setType(DependencyType.REQUIRED)
+      .setLive(filesIsLive)
+      .setReady(filesIsLive);
+  }
+}

--- a/core/src/main/java/com/zextras/carbonio/docs_connector/types/health/DependencyType.java
+++ b/core/src/main/java/com/zextras/carbonio/docs_connector/types/health/DependencyType.java
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.docs_connector.types.health;
+
+import java.io.Serializable;
+
+public enum DependencyType implements Serializable {
+  OPTIONAL,
+  REQUIRED
+}

--- a/core/src/main/java/com/zextras/carbonio/docs_connector/types/health/HealthStatus.java
+++ b/core/src/main/java/com/zextras/carbonio/docs_connector/types/health/HealthStatus.java
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.docs_connector.types.health;
+
+import java.io.Serializable;
+import java.util.List;
+
+public class HealthStatus implements Serializable {
+
+  private boolean ready;
+  private List<ServiceHealth> dependencies;
+
+  public boolean isReady() {
+    return ready;
+  }
+
+  public HealthStatus setReady(boolean ready) {
+    this.ready = ready;
+    return this;
+  }
+
+  public List<ServiceHealth> getDependencies() {
+    return dependencies;
+  }
+
+  public HealthStatus setDependencies(List<ServiceHealth> dependencies) {
+    this.dependencies = dependencies;
+    return this;
+  }
+}

--- a/core/src/main/java/com/zextras/carbonio/docs_connector/types/health/ServiceHealth.java
+++ b/core/src/main/java/com/zextras/carbonio/docs_connector/types/health/ServiceHealth.java
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.docs_connector.types.health;
+
+import java.io.Serializable;
+
+public class ServiceHealth implements Serializable {
+
+  private String name;
+  private boolean ready;
+  private boolean live;
+  private DependencyType type;
+
+  public String getName() {
+    return name;
+  }
+
+  public ServiceHealth setName(String name) {
+    this.name = name;
+    return this;
+  }
+
+  public boolean isReady() {
+    return ready;
+  }
+
+  public ServiceHealth setReady(boolean ready) {
+    this.ready = ready;
+    return this;
+  }
+
+  public boolean isLive() {
+    return live;
+  }
+
+  public ServiceHealth setLive(boolean live) {
+    this.live = live;
+    return this;
+  }
+
+  public DependencyType getType() {
+    return type;
+  }
+
+  public ServiceHealth setType(DependencyType type) {
+    this.type = type;
+    return this;
+  }
+}

--- a/core/src/test/java-it/com/zextras/carbonio/docs_connector/apis/HealthApiIT.java
+++ b/core/src/test/java-it/com/zextras/carbonio/docs_connector/apis/HealthApiIT.java
@@ -1,0 +1,208 @@
+// SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.docs_connector.apis;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zextras.carbonio.docs_connector.apis.Simulator.SimulatorBuilder;
+import com.zextras.carbonio.docs_connector.types.health.DependencyType;
+import com.zextras.carbonio.docs_connector.types.health.HealthStatus;
+import com.zextras.carbonio.docs_connector.types.health.ServiceHealth;
+import jakarta.ws.rs.HttpMethod;
+import jakarta.ws.rs.core.HttpHeaders;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.http.HttpTester;
+import org.eclipse.jetty.http.HttpTester.Response;
+import org.eclipse.jetty.server.LocalConnector;
+import org.junit.jupiter.api.Test;
+import org.mockserver.client.MockServerClient;
+import org.mockserver.model.HttpRequest;
+import org.mockserver.model.HttpResponse;
+
+public class HealthApiIT {
+
+  @Test
+  void givenAllDependenciesHealthyTheHealthShouldReturn200CodeWithTheHealthStatusOfEachDependency()
+    throws Exception {
+    // Given
+    SimulatorBuilder simulatorBuilder =
+      SimulatorBuilder.aSimulator()
+        .init()
+        .withUserManagement()
+        .withFiles();
+
+    try (Simulator simulator = simulatorBuilder.build().start()) {
+
+      LocalConnector localConnector = simulator.getHttpLocalConnector();
+      MockServerClient userManagementServiceMock = simulator.getUserManagementService();
+
+      userManagementServiceMock
+        .when(HttpRequest.request().withMethod(HttpMethod.GET).withPath("/health/"))
+        .respond(HttpResponse.response().withStatusCode(HttpStatus.OK_200));
+
+      MockServerClient filesServiceMock = simulator.getFilesService();
+
+      filesServiceMock
+        .when(HttpRequest.request().withMethod(HttpMethod.GET).withPath("/health/"))
+        .respond(HttpResponse.response().withStatusCode(HttpStatus.OK_200));
+
+      HttpTester.Request request = HttpTester.newRequest();
+      request.setMethod(HttpMethod.GET);
+      request.setHeader(HttpHeaders.HOST, "test");
+      request.setURI(("/health/"));
+
+      // When
+      Response httpFields =
+        HttpTester.parseResponse(HttpTester.from(localConnector.getResponse(request.generate())));
+
+      // Then
+      Assertions.assertThat(httpFields.getStatus()).isEqualTo(HttpStatus.OK_200);
+
+      HealthStatus healthStatus =
+        new ObjectMapper().readValue(httpFields.getContent(), HealthStatus.class);
+
+      Assertions.assertThat(healthStatus.isReady()).isTrue();
+      List<ServiceHealth> dependenciesHealth = healthStatus.getDependencies();
+      Assertions.assertThat(dependenciesHealth).hasSize(2);
+
+      Assertions.assertThat(dependenciesHealth.get(0).getName())
+        .isEqualTo("carbonio-user-management");
+      Assertions.assertThat(dependenciesHealth.get(0).isLive()).isTrue();
+      Assertions.assertThat(dependenciesHealth.get(0).isReady()).isTrue();
+      Assertions.assertThat(dependenciesHealth.get(0).getType()).isEqualTo(DependencyType.REQUIRED);
+
+      Assertions.assertThat(dependenciesHealth.get(1).getName())
+        .isEqualTo("carbonio-files");
+      Assertions.assertThat(dependenciesHealth.get(1).isLive()).isTrue();
+      Assertions.assertThat(dependenciesHealth.get(1).isReady()).isTrue();
+      Assertions.assertThat(dependenciesHealth.get(1).getType()).isEqualTo(DependencyType.REQUIRED);
+    }
+  }
+
+  @Test
+  void
+  givenUserManagementUnreachableAndFilesUnreachableTheHealthShouldReturn502CodeWithTheHealthStatusOfEachDependency()
+    throws Exception {
+    // Given
+    // Notice tha absence of the UserManagement and Files initialization
+    try (Simulator simulator = SimulatorBuilder.aSimulator().init().build().start()) {
+      LocalConnector localConnector = simulator.getHttpLocalConnector();
+
+      HttpTester.Request request = HttpTester.newRequest();
+      request.setMethod(HttpMethod.GET);
+      request.setHeader(HttpHeaders.HOST, "test");
+      request.setURI(("/health/"));
+
+      // When
+      Response httpFields =
+        HttpTester.parseResponse(HttpTester.from(localConnector.getResponse(request.generate())));
+
+      // Then
+      Assertions.assertThat(httpFields.getStatus()).isEqualTo(HttpStatus.BAD_GATEWAY_502);
+
+      HealthStatus healthStatus =
+        new ObjectMapper().readValue(httpFields.getContent(), HealthStatus.class);
+
+      Assertions.assertThat(healthStatus.isReady()).isFalse();
+      List<ServiceHealth> dependenciesHealth = healthStatus.getDependencies();
+      Assertions.assertThat(dependenciesHealth).hasSize(2);
+
+      Assertions.assertThat(dependenciesHealth.get(0).getName()).isEqualTo("carbonio-user-management");
+      Assertions.assertThat(dependenciesHealth.get(0).isLive()).isFalse();
+      Assertions.assertThat(dependenciesHealth.get(0).isReady()).isFalse();
+      Assertions.assertThat(dependenciesHealth.get(0).getType()).isEqualTo(DependencyType.REQUIRED);
+
+      Assertions.assertThat(dependenciesHealth.get(1).getName())
+        .isEqualTo("carbonio-files");
+      Assertions.assertThat(dependenciesHealth.get(1).isLive()).isFalse();
+      Assertions.assertThat(dependenciesHealth.get(1).isReady()).isFalse();
+      Assertions.assertThat(dependenciesHealth.get(1).getType()).isEqualTo(DependencyType.REQUIRED);
+    }
+  }
+
+  @Test
+  void givenAnHealthServiceTheHealthLiveShouldReturn204StatusCode() throws Exception {
+    // Given
+    try (Simulator simulator = SimulatorBuilder.aSimulator().init().build().start()) {
+      LocalConnector localConnector = simulator.getHttpLocalConnector();
+
+      HttpTester.Request request = HttpTester.newRequest();
+      request.setMethod(HttpMethod.GET);
+      request.setHeader(HttpHeaders.HOST, "test");
+      request.setURI(("/health/live/"));
+
+      // When
+      Response httpFields =
+        HttpTester.parseResponse(HttpTester.from(localConnector.getResponse(request.generate())));
+
+      // Then
+      Assertions.assertThat(httpFields.getStatus()).isEqualTo(HttpStatus.NO_CONTENT_204);
+      Assertions.assertThat(httpFields.getContent()).isEmpty();
+    }
+  }
+
+  @Test
+  void givenAllDependenciesHealthyTheHealthReadyShouldReturn204StatusCode() throws Exception {
+    // Given
+    SimulatorBuilder simulatorBuilder =
+      SimulatorBuilder.aSimulator()
+        .init()
+        .withUserManagement()
+        .withFiles();
+
+    try (Simulator simulator = simulatorBuilder.build().start()) {
+
+      LocalConnector localConnector = simulator.getHttpLocalConnector();
+      MockServerClient userManagementServiceMock = simulator.getUserManagementService();
+
+      userManagementServiceMock
+        .when(HttpRequest.request().withMethod(HttpMethod.GET).withPath("/health/"))
+        .respond(HttpResponse.response().withStatusCode(HttpStatus.OK_200));
+
+      MockServerClient filesServiceMock = simulator.getFilesService();
+
+      filesServiceMock
+        .when(HttpRequest.request().withMethod(HttpMethod.GET).withPath("/health/"))
+        .respond(HttpResponse.response().withStatusCode(HttpStatus.OK_200));
+
+      HttpTester.Request request = HttpTester.newRequest();
+      request.setMethod(HttpMethod.GET);
+      request.setHeader(HttpHeaders.HOST, "test");
+      request.setURI(("/health/ready/"));
+
+      // When
+      Response httpFields =
+        HttpTester.parseResponse(HttpTester.from(localConnector.getResponse(request.generate())));
+
+      // Then
+      Assertions.assertThat(httpFields.getStatus()).isEqualTo(HttpStatus.NO_CONTENT_204);
+      Assertions.assertThat(httpFields.getContent()).isEmpty();
+    }
+  }
+
+
+  @Test
+  void givenUserManagementUnreachableAndFilesUnreachableTheHealthReadyShouldReturn502StatusCode() throws Exception {
+    // Given
+    // Notice tha absence of the UserManagement and Files initialization
+    try (Simulator simulator = SimulatorBuilder.aSimulator().init().build().start()) {
+      LocalConnector localConnector = simulator.getHttpLocalConnector();
+
+      HttpTester.Request request = HttpTester.newRequest();
+      request.setMethod(HttpMethod.GET);
+      request.setHeader(HttpHeaders.HOST, "test");
+      request.setURI(("/health/ready/"));
+
+      // When
+      Response httpFields =
+        HttpTester.parseResponse(HttpTester.from(localConnector.getResponse(request.generate())));
+
+      // Then
+      Assertions.assertThat(httpFields.getStatus()).isEqualTo(HttpStatus.BAD_GATEWAY_502);
+      Assertions.assertThat(httpFields.getContent()).isEmpty();
+    }
+  }
+}

--- a/core/src/test/java-it/com/zextras/carbonio/docs_connector/apis/Simulator.java
+++ b/core/src/test/java-it/com/zextras/carbonio/docs_connector/apis/Simulator.java
@@ -5,7 +5,7 @@ import com.google.inject.Injector;
 import com.zextras.carbonio.docs_connector.Constants.Config.FilesService;
 import com.zextras.carbonio.docs_connector.Constants.Config.UserService;
 import com.zextras.carbonio.docs_connector.config.DocsConnectorModule;
-import org.eclipse.jetty.http.HttpMethod;
+import jakarta.ws.rs.HttpMethod;
 import org.eclipse.jetty.server.LocalConnector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
@@ -121,7 +121,7 @@ public class Simulator implements AutoCloseable {
     userManagementServiceMock
       .when(
         HttpRequest.request()
-          .withMethod(HttpMethod.GET.toString())
+          .withMethod(HttpMethod.GET)
           .withPath("/auth/token/" + cookie))
       .respond(
         HttpResponse.response()

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -1,6 +1,6 @@
 pkgname="carbonio-docs-connector-ce"
-pkgver="0.3.3"
-pkgrel="1"
+pkgver="0.4.0"
+pkgrel="SNAPSHOT"
 pkgdesc="Carbonio docs connector"
 maintainer="Zextras <packages@zextras.com>"
 arch=('x86_64')

--- a/package/intentions.json
+++ b/package/intentions.json
@@ -10,6 +10,16 @@
     {
       "Name": "carbonio-docs-editor",
       "Action": "allow"
+    },
+    {
+      "Name": "carbonio-files",
+      "Action": "allow",
+      "HTTP": {
+        "PathPrefix": "/health/live",
+        "Methods": [
+          "GET"
+        ]
+      }
     }
   ]
 }

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
   <groupId>com.zextras.carbonio.docs-connector</groupId>
   <artifactId>carbonio-docs-connector-ce</artifactId>
-  <version>0.3.3-1</version>
+  <version>0.4.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>carbonio-docs-connector-ce</name>


### PR DESCRIPTION
- Added HealthController to expose the following health APIs:
  - /health/
  - /health/live/
  - /health/ready/
- Added HealthService to check the health of the following dependencies:
  - carbonio-user-management
  - carbonio-files
- Added intention for carbonio-files for the /health/live API
- Added integration tests for each API

Refs: DOCS-210