### PR TITLE
feat: update docs connector to use new user management sdk with returned user type

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <properties>
     <assertj.version>3.25.3</assertj.version>
     <caffeine.version>3.1.8</caffeine.version>
-    <carbonio-user-management-sdk.version>0.5.0-SNAPSHOT</carbonio-user-management-sdk.version>
+    <carbonio-user-management-sdk.version>0.5.1-SNAPSHOT</carbonio-user-management-sdk.version>
     <carbonio-files-sdk.version>0.0.3</carbonio-files-sdk.version>
     <guice.version>7.0.0</guice.version>
     <jackson.version>2.17.0</jackson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <properties>
     <assertj.version>3.25.3</assertj.version>
     <caffeine.version>3.1.8</caffeine.version>
-    <carbonio-user-management-sdk.version>0.5.2-SNAPSHOT</carbonio-user-management-sdk.version>
+    <carbonio-user-management-sdk.version>0.5.4-SNAPSHOT</carbonio-user-management-sdk.version>
     <carbonio-files-sdk.version>0.0.3</carbonio-files-sdk.version>
     <guice.version>7.0.0</guice.version>
     <jackson.version>2.17.0</jackson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <properties>
     <assertj.version>3.25.3</assertj.version>
     <caffeine.version>3.1.8</caffeine.version>
-    <carbonio-user-management-sdk.version>0.4.0</carbonio-user-management-sdk.version>
+    <carbonio-user-management-sdk.version>0.5.0-SNAPSHOT</carbonio-user-management-sdk.version>
     <carbonio-files-sdk.version>0.0.3</carbonio-files-sdk.version>
     <guice.version>7.0.0</guice.version>
     <jackson.version>2.17.0</jackson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <properties>
     <assertj.version>3.25.3</assertj.version>
     <caffeine.version>3.1.8</caffeine.version>
-    <carbonio-user-management-sdk.version>0.5.4-SNAPSHOT</carbonio-user-management-sdk.version>
+    <carbonio-user-management-sdk.version>0.5.3</carbonio-user-management-sdk.version>
     <carbonio-files-sdk.version>0.0.3</carbonio-files-sdk.version>
     <guice.version>7.0.0</guice.version>
     <jackson.version>2.17.0</jackson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <properties>
     <assertj.version>3.25.3</assertj.version>
     <caffeine.version>3.1.8</caffeine.version>
-    <carbonio-user-management-sdk.version>0.5.1-SNAPSHOT</carbonio-user-management-sdk.version>
+    <carbonio-user-management-sdk.version>0.5.2-SNAPSHOT</carbonio-user-management-sdk.version>
     <carbonio-files-sdk.version>0.0.3</carbonio-files-sdk.version>
     <guice.version>7.0.0</guice.version>
     <jackson.version>2.17.0</jackson.version>


### PR DESCRIPTION
- Bump carbonio-user-management-sdk version

Refs: DOCS-214