### PR TITLE
fix: update carbonio-files permission in intentions.json

### DIFF
--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -25,7 +25,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <groupId>com.zextras.carbonio.docs-connector</groupId>
     <artifactId>carbonio-docs-connector-ce</artifactId>
-    <version>0.4.0-1</version>
+    <version>0.4.1-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -25,7 +25,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <groupId>com.zextras.carbonio.docs-connector</groupId>
     <artifactId>carbonio-docs-connector-ce</artifactId>
-    <version>0.4.0-1</version>
+    <version>0.4.1-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -1,6 +1,6 @@
 pkgname="carbonio-docs-connector-ce"
-pkgver="0.4.0"
-pkgrel="1"
+pkgver="0.4.1"
+pkgrel="SNAPSHOT"
 pkgdesc="Carbonio docs connector"
 maintainer="Zextras <packages@zextras.com>"
 arch=('x86_64')

--- a/package/intentions.json
+++ b/package/intentions.json
@@ -13,13 +13,17 @@
     },
     {
       "Name": "carbonio-files",
-      "Action": "allow",
-      "HTTP": {
-        "PathPrefix": "/health/live",
-        "Methods": [
-          "GET"
-        ]
-      }
+      "Permissions": [
+        {
+          "Action": "allow",
+          "HTTP": {
+            "PathPrefix": "/health/live",
+            "Methods": [
+              "GET"
+            ]
+          }
+        }
+      ]
     }
   ]
 }

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
   <groupId>com.zextras.carbonio.docs-connector</groupId>
   <artifactId>carbonio-docs-connector-ce</artifactId>
-  <version>0.4.0-1</version>
+  <version>0.4.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>carbonio-docs-connector-ce</name>


### PR DESCRIPTION
With #32, the intentions.json file was updated to allow carbonio-files to call the docs-connector /health/live endpoint, but it was updated with an invalid json structure. Now it is fixed adding the Permissions array.

Refs: DOCS-216