### PR TITLE
build(deps): updated all dependencies/plugins

### DIFF
--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -25,7 +25,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <groupId>com.zextras.carbonio.docs-connector</groupId>
     <artifactId>carbonio-docs-connector-ce</artifactId>
-    <version>0.4.2-1</version>
+    <version>0.4.3-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -25,7 +25,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <groupId>com.zextras.carbonio.docs-connector</groupId>
     <artifactId>carbonio-docs-connector-ce</artifactId>
-    <version>0.4.2-1</version>
+    <version>0.4.3-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -1,6 +1,6 @@
 pkgname="carbonio-docs-connector-ce"
-pkgver="0.4.2"
-pkgrel="1"
+pkgver="0.4.3"
+pkgrel="SNAPSHOT"
 pkgdesc="Carbonio docs connector"
 maintainer="Zextras <packages@zextras.com>"
 arch=('x86_64')

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     <logback-classic.version>1.5.7</logback-classic.version>
     <mock-server.version>5.15.0</mock-server.version>
     <mockito.version>5.13.0</mockito.version>
-    <resteasy.version>6.2.10.Final</resteasy.version>
+    <resteasy.version>6.2.7.Final</resteasy.version>
     <resteasy-guice.version>6.2.7-alpha</resteasy-guice.version>
     <swagger-core-version>2.2.22</swagger-core-version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
   <groupId>com.zextras.carbonio.docs-connector</groupId>
   <artifactId>carbonio-docs-connector-ce</artifactId>
-  <version>0.4.2-1</version>
+  <version>0.4.3-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>carbonio-docs-connector-ce</name>
@@ -33,33 +33,33 @@ SPDX-License-Identifier: AGPL-3.0-only
   </modules>
 
   <properties>
-    <assertj.version>3.25.3</assertj.version>
+    <assertj.version>3.26.3</assertj.version>
     <caffeine.version>3.1.8</caffeine.version>
     <carbonio-user-management-sdk.version>0.5.3</carbonio-user-management-sdk.version>
     <carbonio-files-sdk.version>0.0.3</carbonio-files-sdk.version>
     <guice.version>7.0.0</guice.version>
-    <jackson.version>2.17.0</jackson.version>
-    <jakarta-servlet-api.version>6.0.0</jakarta-servlet-api.version>
-    <jakarta-enterprise.version>4.1.0.RC1</jakarta-enterprise.version>
-    <jetty.version>12.0.7</jetty.version>
-    <jsonassert.version>1.5.1</jsonassert.version>
-    <junit5.version>5.10.2</junit5.version>
-    <logback-classic.version>1.5.3</logback-classic.version>
+    <jackson.version>2.17.2</jackson.version>
+    <jakarta-servlet-api.version>6.1.0</jakarta-servlet-api.version>
+    <jakarta-enterprise.version>4.1.0</jakarta-enterprise.version>
+    <jetty.version>12.0.12</jetty.version>
+    <jsonassert.version>1.5.3</jsonassert.version>
+    <junit5.version>5.11.0</junit5.version>
+    <logback-classic.version>1.5.7</logback-classic.version>
     <mock-server.version>5.15.0</mock-server.version>
-    <mockito.version>5.11.0</mockito.version>
-    <resteasy.version>6.2.7.Final</resteasy.version>
+    <mockito.version>5.13.0</mockito.version>
+    <resteasy.version>6.2.10.Final</resteasy.version>
     <resteasy-guice.version>6.2.7-alpha</resteasy-guice.version>
-    <swagger-core-version>2.2.21</swagger-core-version>
+    <swagger-core-version>2.2.22</swagger-core-version>
 
     <!-- Plugins -->
-    <build-helper-maven.version>3.5.0</build-helper-maven.version>
+    <build-helper-maven.version>3.6.0</build-helper-maven.version>
     <maven-compiler.version>3.13.0</maven-compiler.version>
-    <maven-shade.version>3.5.2</maven-shade.version>
-    <maven-failsafe.version>3.2.5</maven-failsafe.version>
-    <maven-jacoco.version>0.8.11</maven-jacoco.version>
-    <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
+    <maven-shade.version>3.6.0</maven-shade.version>
+    <maven-failsafe.version>3.5.0</maven-failsafe.version>
+    <maven-jacoco.version>0.8.12</maven-jacoco.version>
+    <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
     <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
-    <maven-surfire.version>3.1.2</maven-surfire.version>
+    <maven-surfire.version>3.3.1</maven-surfire.version>
 
     <!-- Other properties -->
     <maven.compiler.source>17</maven.compiler.source>


### PR DESCRIPTION
Updated all dependencies and plugins to the last version:
- assertj: 3.25.3 -> 3.26.3
- jackson: 2.17.0 -> 2.17.2
- jakarta-servlet-api: 6.0.0 -> 6.1.0
- jakarta-enterprise: 4.1.0.RC1 -> 4.1.0
- jetty: 12.0.7 -> 12.0.12
- jsonassert: 1.5.1 -> 1.5.3
- junit5: 5.10.2 -> 5.11.0
- logback-classic: 1.5.3 -> 1.5.7
- mockito: 5.11.0 -> 5.13.0
- resteasy: 6.2.7.Final -> 6.2.10.Final
- swagger-core: 2.2.21 -> 2.2.22

- build-helper-maven: 3.5.0 -> 3.6.0
- maven-shade: 3.5.2 -> 3.6.0
- maven-failsafe: 3.2.5 -> 3.5.0
- maven-jacoco: 0.8.11 -> 0.8.12
- maven-jar-plugin: 3.3.0 -> 3.4.2
- maven-surfire: 3.1.2 -> 3.3.1

Refs: DOCS-221