### PR TITLE
fix: change public URL endpoint returned by openFile

### DIFF
--- a/core/src/main/java/com/zextras/carbonio/docs_connector/controllers/FilesController.java
+++ b/core/src/main/java/com/zextras/carbonio/docs_connector/controllers/FilesController.java
@@ -34,5 +34,6 @@ public interface FilesController {
       @HeaderParam("Cookie") String cookie,
       @PathParam("nodeId") UUID nodeId,
       @QueryParam("version") Integer version,
+      @QueryParam("redirect") Boolean redirect,
       @Context HttpServletRequest httpRequest);
 }

--- a/core/src/main/java/com/zextras/carbonio/docs_connector/controllers/impl/FilesControllerImpl.java
+++ b/core/src/main/java/com/zextras/carbonio/docs_connector/controllers/impl/FilesControllerImpl.java
@@ -33,7 +33,7 @@ public class FilesControllerImpl implements FilesController {
   }
 
   public Response openFile(
-    String cookie, UUID nodeId, Integer version, HttpServletRequest httpRequest) {
+    String cookie, UUID nodeId, Integer version, Boolean redirect, HttpServletRequest httpRequest) {
     String requesterId = (String) httpRequest.getAttribute(Context.REQUESTER_ID);
     String requesterDomain = (String) httpRequest.getAttribute(Context.REQUESTER_DOMAIN);
     Locale requesterLocale = (Locale) httpRequest.getAttribute(Context.REQUESTER_LOCALE);
@@ -46,11 +46,11 @@ public class FilesControllerImpl implements FilesController {
         nodeId.toString(),
         Optional.ofNullable(version)
       );
+      String docsRedirectURL = "%s/%s".formatted(requesterDomain, docsEditorURL);
 
-      return Response
-        .ok()
-        .entity(new DocsEditorRedirect("%s/%s".formatted(requesterDomain, docsEditorURL)))
-        .build();
+      return (redirect != null && redirect)
+        ? Response.temporaryRedirect(URI.create(docsRedirectURL)).build()
+        : Response.ok().entity(new DocsEditorRedirect(docsRedirectURL)).build();
 
     } catch (FileSizeTooLargeException exception) {
       return Response.status(Status.FORBIDDEN).entity(exception).build();

--- a/core/src/main/java/com/zextras/carbonio/docs_connector/services/FilesService.java
+++ b/core/src/main/java/com/zextras/carbonio/docs_connector/services/FilesService.java
@@ -79,10 +79,20 @@ public class FilesService {
     optVersion
       .map(version -> wopiEndpointBuilder.append("?version=").append(version));
 
-    // Public URL
+    // Public URL, it contains the redirect=true to allow the controller to return 307. Optionally,
+    // it can contain the version:
+    // - services/docs/files/open/<node_id>?redirect=true
+    // - services/docs/files/open/<node_id>?version=<version>&redirect=true
     StringBuilder publicURLBuilder = new StringBuilder()
-      .append("docs/editor/")
-      .append(nodeId);
+      .append("services/docs/files/open/")
+      .append(nodeId)
+      .append("?");
+
+    optVersion
+      .map(version -> publicURLBuilder.append("version=").append(version).append("&"));
+
+    publicURLBuilder.append("redirect=true");
+
 
     // Cool html resource + token parameter
     StringBuilder docsPathAndParametersBuilder = new StringBuilder()

--- a/core/src/main/java/com/zextras/carbonio/docs_connector/types/DocsEditorRedirect.java
+++ b/core/src/main/java/com/zextras/carbonio/docs_connector/types/DocsEditorRedirect.java
@@ -2,4 +2,3 @@ package com.zextras.carbonio.docs_connector.types;
 
 public record DocsEditorRedirect(String fileOpenUrl) {
 }
-

--- a/core/src/main/resources/api/rest.yaml
+++ b/core/src/main/resources/api/rest.yaml
@@ -31,6 +31,7 @@ paths:
         - $ref: '#/components/parameters/headerCookies'
         - $ref: '#/components/parameters/pathNodeId'
         - $ref: '#/components/parameters/queryNodeVersion'
+        - $ref: '#/components/parameters/queryRedirect'
       responses:
         '307':
           $ref: '#/components/responses/307DocsEditorRedirectResponse'
@@ -122,6 +123,14 @@ components:
         type: integer
       required: false
       description: The version of the Files node
+
+    queryRedirect:
+      in: query
+      name: redirect
+      schema:
+        type: boolean
+      required: false
+      description: Allows to specify if the response of the API should return a 307 or a 200 status code with the URL in the json response
 
     queryAccessToken:
       in: query

--- a/core/src/test/java-it/com/zextras/carbonio/docs_connector/apis/OpenFileApiIT.java
+++ b/core/src/test/java-it/com/zextras/carbonio/docs_connector/apis/OpenFileApiIT.java
@@ -29,6 +29,31 @@ public class OpenFileApiIT {
 
   static Simulator simulator;
   static List<String> expectationIds;
+  static String filesGetNodeResponseFormat = """
+              {
+              "data": {
+                  "getNode": {
+                      "permissions": {
+                          "can_write_file": true
+                      },
+                      "owner": {
+                          "id": "%s",
+                          "full_name": "Fake user"
+                      },
+                      "parent": {
+                          "id": "LOCAL_ROOT"
+                      },
+                      "id": "%s",
+                      "name": "test-file",
+                      "updated_at": 100,
+                      "extension": "%s",
+                      "mime_type": "%s",
+                      "size": %d,
+                      "version": 1
+                  }
+              }
+          }
+    """;
 
   @BeforeAll
   static void init() {
@@ -62,7 +87,7 @@ public class OpenFileApiIT {
 
     return Stream.of(
       Arguments.of(
-         "document",
+        "document",
         10L,
         "application/vnd.oasis.opendocument.text", "odt",
         elevenMbInBytes
@@ -85,9 +110,9 @@ public class OpenFileApiIT {
   }
 
   @DisplayName("Given a valid user cookie and an accessible node id the openFile API should"
-    + "return a redirect containing the URL of the document to open with Docs")
+    + "return a 200 and a payload containing the URL of the document to open with Docs")
   @Test
-  void givenAValidUserCookieAndAnAccessibleNodeIdTheOpenFileApiShouldReturnARedirectContainingTheUrlToOpenTheDocumentWithDocs()
+  void givenAValidUserCookieAndAnAccessibleNodeIdTheOpenFileApiShouldReturnA200ContainingTheUrlToOpenTheDocumentWithDocs()
     throws Exception {
     // Given
     String userCookie = "ZM_AUTH_TOKEN=9e2cffc4";
@@ -106,31 +131,13 @@ public class OpenFileApiIT {
       .respond(HttpResponse
         .response()
         .withStatusCode(HttpStatus.OK_200)
-        .withBody("""
-          {
-              "data": {
-                  "getNode": {
-                      "permissions": {
-                          "can_write_file": true
-                      },
-                      "owner": {
-                          "id": "9e2cffc4-5860-4095-aedb-7b48d6ff889a",
-                          "full_name": "Fake user"
-                      },
-                      "parent": {
-                          "id": "LOCAL_ROOT"
-                      },
-                      "id": "58032253-ed56-4eca-9017-3ae26cc2d9f1",
-                      "name": "test-file",
-                      "updated_at": 100,
-                      "extension": "odt",
-                      "mime_type": "application/vnd.oasis.opendocument.text",
-                      "size": 52428800,
-                      "version": 1
-                  }
-              }
-          }
-          """)
+        .withBody(filesGetNodeResponseFormat.formatted(
+          requesterId,
+          nodeId,
+          "odt",
+          "application/vnd.oasis.opendocument.text",
+          52428800
+        ))
       )[0].getId()
     );
 
@@ -158,8 +165,60 @@ public class OpenFileApiIT {
         "&ui_defaults=UIMode=classic;UIMode=classic;TextSidebar=false;PresentationSidebar=false;SpreadsheetSidebar=false")
       .contains("&WOPISrc")
       .contains(nodeId)
-      .contains("&public_url=docs%2Feditor%2F58032253-ed56-4eca-9017-3ae26cc2d9f1")
+      .contains("&public_url=services%2Fdocs%2Ffiles%2Fopen%2F58032253-ed56-4eca-9017-3ae26cc2d9f1%3Fredirect%3Dtrue")
       .contains("&lang=pt-BR");
+  }
+
+  @DisplayName("Given a valid user cookie and an accessible node id the openFile API with the "
+    + "redirect query params to true should return a redirect containing the URL of the document "
+    + "to open with Docs")
+  @Test
+  void givenAValidUserCookieAndAnAccessibleNodeIdTheOpenFileApiShouldReturnARedirectContainingTheUrlToOpenTheDocumentWithDocs()
+    throws Exception {
+    // Given
+    String userCookie = "ZM_AUTH_TOKEN=9e2cffc4";
+    String requesterId = "9e2cffc4-5860-4095-aedb-7b48d6ff889a";
+    String nodeId = "58032253-ed56-4eca-9017-3ae26cc2d9f1";
+
+    expectationIds.add(simulator.mockValidateUser("9e2cffc4", requesterId));
+    expectationIds.add(simulator.mockGetMyself(userCookie, requesterId, "pt_BR"));
+
+    expectationIds.add(simulator.getFilesService()
+      .when(HttpRequest
+        .request("/graphql/")
+        .withCookie(Cookie.cookie("ZM_AUTH_TOKEN", "9e2cffc4"))
+        .withBody(NodeAttributes.getNodeGraphQLRequest(nodeId, Optional.empty()))
+      )
+      .respond(HttpResponse
+        .response()
+        .withStatusCode(HttpStatus.OK_200)
+        .withBody(filesGetNodeResponseFormat.formatted(
+          requesterId,
+          nodeId,
+          "odt",
+          "application/vnd.oasis.opendocument.text",
+          20
+        ))
+      )[0].getId()
+    );
+
+    LocalConnector httpLocalConnector = simulator.getHttpLocalConnector();
+    HttpTester.Request request = HttpTester.newRequest();
+    request.setMethod(HttpMethod.GET.toString());
+    request.setHeader(HttpHeaders.HOST.toString(), "test");
+    request.setHeader(HttpHeaders.COOKIE.toString(), userCookie);
+    request.setURI("/files/open/%s?redirect=true".formatted(nodeId));
+
+    // When
+    Response response = HttpTester.parseResponse(
+      httpLocalConnector.getResponse(request.generate())
+    );
+
+    // Then
+    Assertions.assertThat(response.getStatus()).isEqualTo(HttpStatus.TEMPORARY_REDIRECT_307);
+    Assertions
+      .assertThat(response.get(HttpHeaders.LOCATION))
+      .contains("/services/docs/editor/browser/dist/cool.html");
   }
 
   @DisplayName("Given a valid cookie of a user and an invalid node id, "
@@ -273,31 +332,13 @@ public class OpenFileApiIT {
       .respond(HttpResponse
         .response()
         .withStatusCode(HttpStatus.OK_200)
-        .withBody("""
-          {
-              "data": {
-                  "getNode": {
-                      "permissions": {
-                          "can_write_file": true
-                      },
-                      "owner": {
-                          "id": "%s",
-                          "full_name": "Fake user"
-                      },
-                      "parent": {
-                          "id": "LOCAL_ROOT"
-                      },
-                      "id": "%s",
-                      "name": "test-file",
-                      "updated_at": 100,
-                      "extension": "%s",
-                      "mime_type": "%s",
-                      "size": %d,
-                      "version": 1
-                  }
-              }
-          }
-          """.formatted(requesterId, nodeId, fileExtension, fileMimeType, fileSize))
+        .withBody(filesGetNodeResponseFormat.formatted(
+          requesterId,
+          nodeId,
+          fileExtension,
+          fileMimeType,
+          fileSize
+        ))
       )[0].getId());
 
     expectationIds.add(simulator.mockServiceDiscoverConfig(


### PR DESCRIPTION
- Fixed the public URL returned by the openFile API, now it points to the right resource. These are the two possible public endpoints:
  - services/docs/files/open/<node_id>?redirect=true
  - services/docs/files/open/<node_id>?version=<version>&redirect=true
- Refactored the openFile API to accept a new optional query parameter "redirect". When it is set to true, the API returns a 307 status code and the URL to redirect is saved in the Location header
- Added IT and refactored the OpenFileApiIT test class

Refs: DOCS-223