### PR TITLE
fix: save only auth token instead of all cookie

### DIFF
--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -25,7 +25,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <groupId>com.zextras.carbonio.docs-connector</groupId>
     <artifactId>carbonio-docs-connector-ce</artifactId>
-    <version>0.5.1-1</version>
+    <version>0.5.2-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -25,7 +25,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <groupId>com.zextras.carbonio.docs-connector</groupId>
     <artifactId>carbonio-docs-connector-ce</artifactId>
-    <version>0.5.1-1</version>
+    <version>0.5.2-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/core/src/main/java/com/zextras/carbonio/docs_connector/dal/repositories/impl/OpenDocumentTokenRepositoryInMemory.java
+++ b/core/src/main/java/com/zextras/carbonio/docs_connector/dal/repositories/impl/OpenDocumentTokenRepositoryInMemory.java
@@ -12,6 +12,8 @@ import java.time.Clock;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class OpenDocumentTokenRepositoryInMemory implements OpenDocumentTokenRepository {
 
@@ -30,11 +32,25 @@ public class OpenDocumentTokenRepositoryInMemory implements OpenDocumentTokenRep
     String requesterId,
     String requesterCookie
   ) {
+    // Extract only the relevant token we need
+    String zmAuthTokenCookie = null;
+    if (requesterCookie != null) {
+        Matcher matcher = Pattern
+            .compile("ZM_AUTH_TOKEN=([a-zA-Z0-9_]+)(;|$)")
+            .matcher(requesterCookie);
+
+        if (matcher.find()) {
+            zmAuthTokenCookie = matcher.group();
+        } else {
+            throw new IllegalArgumentException("ZM_AUTH_TOKEN not found in requester cookie");
+        }
+    }
+
     OpenDocumentToken token = new OpenDocumentToken(
       UUID.randomUUID(),
       documentId,
       requesterId,
-      requesterCookie,
+      zmAuthTokenCookie,
       Instant.ofEpochMilli(clock.millis() + cacheManager.getTokenDurationInMs())
     );
 

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
 pkgname="carbonio-docs-connector-ce"
-pkgver="0.5.1"
-pkgrel="1"
+pkgver="0.5.2"
+pkgrel="SNAPSHOT"
 pkgdesc="Carbonio docs connector"
 maintainer="Zextras <packages@zextras.com>"
 arch=('x86_64')

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
   <groupId>com.zextras.carbonio.docs-connector</groupId>
   <artifactId>carbonio-docs-connector-ce</artifactId>
-  <version>0.5.1-1</version>
+  <version>0.5.2-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>carbonio-docs-connector-ce</name>


### PR DESCRIPTION
- Save only ZM_AUTH_TOKEN instead of all cookie when creating opendocumenttoken

Refs: DOCS-229