### PR TITLE
chore: migrate Jenkinsfile to jenkins-lib-common@1.1.2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,11 +12,11 @@ library(
 )
 
 library(
-    identifier: 'jenkins-packages-build-library@1.0.4',
+    identifier: 'jenkins-lib-common@1.1.2',
     retriever: modernSCM([
         $class: 'GitSCMSource',
-        remote: 'git@github.com:zextras/jenkins-packages-build-library.git',
-        credentialsId: 'jenkins-integration-with-github-account'
+        credentialsId: 'jenkins-integration-with-github-account',
+        remote: 'git@github.com:zextras/jenkins-lib-common.git',
     ])
 )
 
@@ -40,9 +40,6 @@ pipeline {
     }
 
     parameters {
-        booleanParam defaultValue: false,
-            description: 'Whether to upload the packages in playground repositories',
-            name: 'PLAYGROUND'
         booleanParam(
             name: 'PREPARE_RELEASE',
             defaultValue: false,
@@ -60,15 +57,13 @@ pipeline {
         )
     }
 
-    tools {
-        jfrog 'jfrog-cli'
-    }
-
     stages {
-        stage('Checkout') {
+        stage('Setup') {
             steps {
+                checkout scm
                 script {
-                    checkoutWithMetadata()
+                    gitMetadata()
+                    properties(defaultPipelineProperties())
                 }
             }
         }
@@ -161,12 +156,18 @@ pipeline {
         }
 
         stage('Upload artifacts') {
+            when {
+                expression { return uploadStage.shouldUpload() }
+            }
+            tools {
+                jfrog 'jfrog-cli'
+            }
             steps {
-                uploadStage(
-                    packages: yapHelper.getPackageNames(),
+                uploadStage([
+                    packages: yapHelper.resolvePackageNames(),
                     rockySinglePkg: true,
-                    ubuntuSinglePkg: true
-                )
+                    ubuntuSinglePkg: true,
+                ])
             }
         }
 
@@ -216,19 +217,16 @@ pipeline {
             }
         }
 
-        stage('Build and Publish Docker Image') {
-            when {
-                not {
-                    expression { env.BRANCH_NAME.startsWith('PR-') }
-                }
-            }
+        stage('Publish docker images') {
             steps {
-                buildAndPublishDockerImage(
-                    projectName: 'carbonio-docs-connector-ce',
+                dockerStage([
                     dockerfile: 'docker/minimal/carbonio-docs-connector/Dockerfile',
-                    imageTitle: 'Carbonio Docs Connector CE',
-                    imageDescription: 'Carbonio Docs Connector Advanced Community Edition'
-                )
+                    imageName: 'registry.dev.zextras.com/dev/carbonio-docs-connector-ce',
+                    ocLabels: [
+                        title: 'Carbonio Docs Connector CE',
+                        description: 'Carbonio Docs Connector Advanced Community Edition',
+                    ]
+                ])
             }
         }
     }


### PR DESCRIPTION
Migrates Jenkinsfile from deprecated `jenkins-packages-build-library@1.0.4` to `jenkins-lib-common@1.1.2`.

## Changes

- **Library migration**: Updated to `jenkins-lib-common@1.1.2` from `jenkins-packages-build-library@1.0.4`
- **Parameters cleanup**: Removed unused `PLAYGROUND` parameter
- **Setup stage enhancement**: Renamed `Checkout` → `Setup` and added `properties(defaultPipelineProperties())` call
- **Tool scoping**: Moved `jfrog` tool declaration from pipeline-level to `Upload artifacts` stage
- **Docker stage**: Updated to use `dockerStage()` function

```groovy
// Before: global tools declaration
pipeline {
    tools {
        jfrog 'jfrog-cli'
    }
}

// After: stage-scoped tool
stage('Upload artifacts') {
    tools {
        jfrog 'jfrog-cli'
    }
    steps { ... }
}
```

Resolve: [IN-959](https://zextras.atlassian.net/browse/IN-959)

[IN-959]: https://zextras.atlassian.net/browse/IN-959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ