### PR TITLE
build: upgrade JDK from 17 to 21

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,7 +75,7 @@ pipeline {
                     if (env.TAG_NAME) {
                         profile = '-P prod'
                     }
-                    container('jdk-17') {
+                    container('jdk-21') {
                         sh """
                             mvn -B clean package ${profile}
                             cp boot/target/carbonio-docs-connector-*-fatjar.jar package/carbonio-docs-connector.jar
@@ -90,7 +90,7 @@ pipeline {
                 expression { params.SKIP_TESTS == false }
             }
             steps {
-                container('jdk-17') {
+                container('jdk-21') {
                     sh 'mvn -B verify -P run-unit-tests'
                 }
             }
@@ -101,7 +101,7 @@ pipeline {
                 expression { params.SKIP_TESTS == false }
             }
             steps {
-                container('jdk-17') {
+                container('jdk-21') {
                     sh 'mvn -B verify -P run-integration-tests'
                 }
             }
@@ -112,7 +112,7 @@ pipeline {
                 expression { params.SKIP_CHECKS == false }
             }
             steps {
-                container('jdk-17') {
+                container('jdk-21') {
                     sh 'mvn -B verify -P generate-jacoco-full-report'
                     recordCoverage(
                         tools: [[parser: 'JACOCO']],
@@ -133,7 +133,7 @@ pipeline {
                }
             }
             steps {
-                container('jdk-17') {
+                container('jdk-21') {
                     withSonarQubeEnv(credentialsId: 'sonarqube-user-token', installationName: 'SonarQube instance') {
                         sh 'mvn -B sonar:sonar'
                     }

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -209,10 +209,16 @@ SPDX-License-Identifier: AGPL-3.0-only
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>${maven-surfire.version}</version>
-        <configuration>
-          <skipTests>${skip.unit.tests}</skipTests>
-        </configuration>
+        <version>${maven-surefire.version}</version>
+          <configuration>
+              <skipTests>${skip.unit.tests}</skipTests>
+              <argLine>
+                  -javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar
+              </argLine>
+              <systemPropertyVariables>
+                  <slf4j.provider>ch.qos.logback.classic.spi.LogbackServiceProvider</slf4j.provider>
+              </systemPropertyVariables>
+          </configuration>
       </plugin>
 
       <plugin>

--- a/core/src/test/java-it/com/zextras/carbonio/docs_connector/apis/Simulator.java
+++ b/core/src/test/java-it/com/zextras/carbonio/docs_connector/apis/Simulator.java
@@ -92,7 +92,8 @@ public class Simulator implements AutoCloseable {
 
   private void startUserManagementService() {
     startMockServer();
-    userManagementServiceMock = new MockServerClient(UserManagement.DEFAULT_HOST, UserManagement.DEFAULT_PORT);
+    userManagementServiceMock = new MockServerClient("localhost", UserManagement.DEFAULT_PORT);
+    System.setProperty(UserManagement.HOST_PROPERTY, "localhost");
   }
 
   private void stopUserManagementService() {
@@ -103,7 +104,8 @@ public class Simulator implements AutoCloseable {
 
   private void startFilesService() {
     startMockServer();
-    filesServiceMock = new MockServerClient(Files.DEFAULT_HOST, Files.DEFAULT_PORT);
+    filesServiceMock = new MockServerClient("localhost", Files.DEFAULT_PORT);
+    System.setProperty(Files.HOST_PROPERTY, "localhost");
   }
 
   private void stopFilesService() {

--- a/docker/minimal/carbonio-docs-connector/Dockerfile
+++ b/docker/minimal/carbonio-docs-connector/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jdk-alpine
+FROM eclipse-temurin:21-jdk-alpine
 
 WORKDIR /app
 

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     <junit5.version>5.11.0</junit5.version>
     <logback-classic.version>1.5.7</logback-classic.version>
     <mock-server.version>5.15.0</mock-server.version>
-    <mockito.version>5.13.0</mockito.version>
+    <mockito.version>5.20.0</mockito.version>
     <resteasy.version>6.2.7.Final</resteasy.version>
     <resteasy-guice.version>6.2.7-alpha</resteasy-guice.version>
     <swagger-core-version>2.2.22</swagger-core-version>
@@ -61,12 +61,12 @@ SPDX-License-Identifier: AGPL-3.0-only
     <maven-jacoco.version>0.8.12</maven-jacoco.version>
     <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
     <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
-    <maven-surfire.version>3.3.1</maven-surfire.version>
+    <maven-surefire.version>3.5.4</maven-surefire.version>
 
     <!-- Other properties -->
-    <maven.compiler.source>17</maven.compiler.source>
-    <maven.compiler.target>17</maven.compiler.target>
-    <java-compiler.version>17</java-compiler.version>
+    <maven.compiler.source>21</maven.compiler.source>
+    <maven.compiler.target>21</maven.compiler.target>
+    <java-compiler.version>21</java-compiler.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- Flags to skip/run tests and the report generation -->


### PR DESCRIPTION
- Upgrade mockito version from 5.13.0 to 5.20.0
- Upgrade maven-surefire-plugin version from 3.3.1 to 3.5.4
- Update Java version to 21 in pom.xml files
- Configure Mockito agent for JDK 21 compatibility
- Update maven-surefire-plugin configuration
- Set localhost as host for UserManagement and Files in Simulator

ref: CO-2825