### PR TITLE
ci: migrate to mavenStage() from jenkins-lib-common

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -64,7 +64,7 @@ pipeline {
                 script {
                     mavenStage(
                         splitTests: true,
-                        postBuildScript: 'cp boot/target/carbonio-docs-connector-*-fatjar.jar package/carbonio-docs-connector.jar',
+                        postBuildScript: 'cp boot/target/carbonio-docs-connector-*-fatjar.jar package/carbonio-docs-connector.jar'
                     )
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,16 +47,6 @@ pipeline {
             defaultValue: false,
             description: 'Check this to prepare a new release (creates pre-release branch and PR)'
         )
-        booleanParam(
-            name: 'SKIP_TESTS',
-            defaultValue: false,
-            description: 'Skip unit tests and integration tests'
-        )
-        booleanParam(
-            name: 'SKIP_CHECKS',
-            defaultValue: false,
-            description: 'Skip coverage and SonarQube analysis'
-        )
     }
 
     stages {
@@ -69,75 +59,13 @@ pipeline {
             }
         }
 
-        stage('Build jar') {
+        stage('Maven') {
             steps {
                 script {
-                    def profile = '-P dev'
-                    if (env.TAG_NAME) {
-                        profile = '-P prod'
-                    }
-                    container('jdk-21') {
-                        sh """
-                            mvn -B clean package ${profile}
-                            cp boot/target/carbonio-docs-connector-*-fatjar.jar package/carbonio-docs-connector.jar
-                        """
-                    }
-                }
-            }
-        }
-
-        stage('Unit tests') {
-            when {
-                expression { params.SKIP_TESTS == false }
-            }
-            steps {
-                container('jdk-21') {
-                    sh 'mvn -B verify -P run-unit-tests'
-                }
-            }
-        }
-
-        stage('Integration tests') {
-            when {
-                expression { params.SKIP_TESTS == false }
-            }
-            steps {
-                container('jdk-21') {
-                    sh 'mvn -B verify -P run-integration-tests'
-                }
-            }
-        }
-
-        stage('Coverage') {
-            when {
-                expression { params.SKIP_CHECKS == false }
-            }
-            steps {
-                container('jdk-21') {
-                    sh 'mvn -B verify -P generate-jacoco-full-report'
-                    recordCoverage(
-                        tools: [[parser: 'JACOCO']],
-                        sourceCodeRetention: 'MODIFIED'
+                    mavenStage(
+                        splitTests: true,
+                        postBuildScript: 'cp boot/target/carbonio-docs-connector-*-fatjar.jar package/carbonio-docs-connector.jar',
                     )
-                }
-            }
-        }
-
-        stage('SonarQube analysis') {
-            when {
-               allOf {
-                   expression { params.SKIP_CHECKS == false }
-                   anyOf {
-                       branch 'devel'
-                       expression { env.BRANCH_NAME.contains("PR") }
-                   }
-               }
-            }
-            steps {
-                container('jdk-21') {
-                    withSonarQubeEnv(credentialsId: 'sonarqube-user-token', installationName: 'SonarQube instance') {
-                        sh 'mvn -B sonar:sonar'
-                    }
                 }
             }
         }


### PR DESCRIPTION
## What

Replace hand-rolled Maven stages with `mavenStage()` from `jenkins-lib-common@1.5.0`.

## Why

Reduce boilerplate. `mavenStage` handles credentials wrapping, JaCoCo auto-detection, SonarQube gating, and test recording automatically.

## Changes

- Replace `Build jar`, `Unit tests`, `Integration tests`, `Coverage`, `SonarQube analysis` stages with single `mavenStage(splitTests: true, postBuildScript: '...')`
- Remove `SKIP_TESTS` and `SKIP_CHECKS` pipeline parameters (superseded by `mavenStage`)
- `postBuildScript` copies fatjar to `package/` for downstream `buildPackages`/`dockerStage`

## Profile

Auto-detect matches current behavior: `-P dev` on branch, `-P prod` on tag.

## Behavior notes

- `junit` recording now active (was missing before)
- `recordCoverage` same logic (JaCoCo auto-detected from POM)
- SonarQube gating unchanged (`devel` + `PR-*`)
- No deploy stage (unchanged)