### PR TITLE
chore(deps): bump user-management SDK + remove setToken

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ LICENSES
 
 # VS Code
 .vscode/.run/
+
+# Build artifacts
+docker/packaging/artifacts/

--- a/core/src/main/java/com/zextras/carbonio/docs_connector/services/WopiService.java
+++ b/core/src/main/java/com/zextras/carbonio/docs_connector/services/WopiService.java
@@ -51,13 +51,10 @@ public class WopiService {
     Optional<Integer> optVersion,
     Optional<Integer> optOffsetFromUtc
   ) {
-    // Extract raw token from cookie string (format: "ZM_AUTH_TOKEN=<value>" or full cookie header)
-    String token = extractToken(requesterCookie);
-
     UserInfoProto userInfo;
     try {
       GetUserByIdRequest request =
-          GetUserByIdRequest.newBuilder().setToken(token).setUserId(requesterId).build();
+          GetUserByIdRequest.newBuilder().setUserId(requesterId).build();
       userInfo = userManagementStub.getUserById(request).getUser();
     } catch (StatusRuntimeException e) {
       logger.error("Unable to retrieve user info of user id {}", requesterId, e);

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     <revision>1.0.1</revision>
     <assertj.version>3.27.6</assertj.version>
     <caffeine.version>3.2.0</caffeine.version>
-    <carbonio-user-management-grpc-sdk.version>1.0.3-dev.20.719a98d8</carbonio-user-management-grpc-sdk.version>
+    <carbonio-user-management-grpc-sdk.version>1.0.3-dev.21.79fc3fa2</carbonio-user-management-grpc-sdk.version>
     <io.grpc.version>1.73.0</io.grpc.version>
     <carbonio-files-sdk.version>1.0.1</carbonio-files-sdk.version>
     <consul-client.version>1.5.3</consul-client.version>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     <revision>1.0.1</revision>
     <assertj.version>3.27.6</assertj.version>
     <caffeine.version>3.2.0</caffeine.version>
-    <carbonio-user-management-grpc-sdk.version>1.0.3-dev.1.324e7740</carbonio-user-management-grpc-sdk.version>
+    <carbonio-user-management-grpc-sdk.version>1.0.3-dev.20.719a98d8</carbonio-user-management-grpc-sdk.version>
     <io.grpc.version>1.73.0</io.grpc.version>
     <carbonio-files-sdk.version>1.0.1</carbonio-files-sdk.version>
     <consul-client.version>1.5.3</consul-client.version>


### PR DESCRIPTION
## Summary
- Bumps `carbonio-user-management-grpc-sdk` to `1.0.3-dev.21.79fc3fa2`
- Removes `.setToken(token)` from `GetUserByIdRequest` (field removed in SDK)
- New SDK version includes protobuf-java 4.33.2 pin from `sdk-parent:1.8.2-1`

## Test plan
- [x] Jenkins build GREEN on `update-um`

🤖 Generated with [Claude Code](https://claude.com/claude-code)