### PR TITLE
ci(jenkins): switch Prepare Release agent to sm-release-v1

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -100,7 +100,7 @@ pipeline {
         stage('Prepare Release') {
             agent {
                 node {
-                    label 'nodejs-v1'
+                    label 'sm-release-v1'
                 }
             }
             when {
@@ -117,7 +117,7 @@ pipeline {
             }
             steps {
                 script {
-                    container('nodejs-20') {
+                    container('nodejs-22') {
                         prepareRelease(
                             repoName: 'carbonio-docs-connector-ce'
                         )


### PR DESCRIPTION
Fixes pod parking deadlock by migrating Prepare Release stage to sm-release-v1 agent label and Node.js 22 container.