### PR TITLE
chore: bump jenkins-lib-common to 1.7.2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ library(
 )
 
 library(
-    identifier: 'jenkins-lib-common@1.7.1',
+    identifier: 'jenkins-lib-common@1.7.2',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         credentialsId: 'jenkins-integration-with-github-account',


### PR DESCRIPTION
## Summary
- Bumps \`jenkins-lib-common\` from the current pinned version to \`1.7.2\`
- Fixes DinD wait bug introduced in 1.7.0 (unconditional \`docker info\` wait)
- Picks up \`detectTestcontainers()\` guard and increased timeout (300s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)