### PR TITLE
chore(deps): bump jenkins-lib-common to v2.8.8

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ library(
 )
 
 library(
-    identifier: 'jenkins-lib-common@v2.8.6',
+    identifier: 'jenkins-lib-common@v2.8.8',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         credentialsId: 'jenkins-integration-with-github-account',


### PR DESCRIPTION
* Update jenkins-lib-common dependency version
* Ensure compatibility with latest features and fixes