### PR TITLE
fix(releaserc): publish from devel instead of pre-release

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,5 @@
 {
-  "branches": ["pre-release"],
+  "branches": ["devel"],
   "repositoryUrl": "https://github.com/zextras/carbonio-docs-connector-ce",
   "tagFormat": "v${version}",
   "plugins": [


### PR DESCRIPTION
## Problem

`semantic-release` was configured to publish only from the `pre-release` branch:

```json
"branches": ["pre-release"]
```

When run on `devel` (with `PREPARE_RELEASE=true`), it aborted with:

> This test run was triggered on the branch devel, while semantic-release is configured to only publish from pre-release, therefore a new version won't be published.

## Fix

Change the publish branch to `devel`, which is where the actual release builds run from.