### PR TITLE
fix(package): set pkgrel to 1 for release builds

### DIFF
--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname="carbonio-docs-connector-ce"
 pkgver="1.1.1"
-pkgrel="SNAPSHOT"
+pkgrel="1"
 pkgdesc="Carbonio docs connector"
 maintainer="Zextras <packages@zextras.com>"
 arch=('x86_64')


### PR DESCRIPTION
## Problem

Tag builds (`v1.1.1`) were producing SNAPSHOT artifacts (`1.1.1-SNAPSHOT.el8.x86_64.rpm`) because `pkgrel` was hardcoded to `"SNAPSHOT"` in `package/PKGBUILD`. The CI `artifactoryHelper` correctly rejects uploads to RC/release repositories when it detects SNAPSHOT version strings, causing the build to fail.

## Fix

Set `pkgrel="1"` to match the non-CE sibling repo (`carbonio-docs-connector`) which builds successfully with the same tag.