### PR TITLE
feat(ci): [IN-951] add arm64 platform to docker image builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -112,6 +112,7 @@ pipeline {
                 dockerStage(
                     dockerfile: 'docker/minimal/carbonio-docs-connector/Dockerfile',
                     imageName: 'registry.dev.zextras.com/dev/carbonio-docs-connector-ce',
+                    platforms: ['linux/amd64', 'linux/arm64'] as Set,
                     ocLabels: [
                         title: 'Carbonio Docs Connector CE',
                         description: 'Carbonio Docs Connector Advanced Community Edition'

--- a/docker/minimal/carbonio-docs-connector/Dockerfile
+++ b/docker/minimal/carbonio-docs-connector/Dockerfile
@@ -1,8 +1,13 @@
+# Prep stage runs on BUILDPLATFORM (amd64 CI builder) — no QEMU. Creates the
+# arch-independent config dir so the final image needs no RUN step.
+FROM --platform=$BUILDPLATFORM busybox AS prep
+RUN mkdir -p /staging/etc/carbonio/docs-connector
+
 FROM eclipse-temurin:21-jdk-alpine
 
 WORKDIR /app
 
-RUN mkdir -p /etc/carbonio/docs-connector
+COPY --from=prep /staging/etc /etc
 
 COPY ../../boot/target/carbonio-docs-connector-*-fatjar.jar .
 


### PR DESCRIPTION
Adds `platforms: ['linux/amd64', 'linux/arm64'] as Set` to each `dockerStage` call so images build for arm64 (Apple Silicon / MacOS) in addition to amd64.

Mirrors the merged carbonio-mailbox pattern (PR #994). The `as Set` cast is required: dockerHelper only emits `--platform` when platforms is a Set.

Ref: IN-951