### PR TITLE
build: migrate to buildah (FQDN images + jenkins-lib-common@2.10.0)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ library(
 )
 
 library(
-    identifier: 'jenkins-lib-common@v2.9.2',
+    identifier: 'jenkins-lib-common@v2.10.0',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         credentialsId: 'jenkins-integration-with-github-account',

--- a/docker/minimal/carbonio-docs-connector/Dockerfile
+++ b/docker/minimal/carbonio-docs-connector/Dockerfile
@@ -1,9 +1,9 @@
 # Prep stage runs on BUILDPLATFORM (amd64 CI builder) — no QEMU. Creates the
 # arch-independent config dir so the final image needs no RUN step.
-FROM --platform=$BUILDPLATFORM busybox AS prep
+FROM --platform=$BUILDPLATFORM docker.io/library/busybox AS prep
 RUN mkdir -p /staging/etc/carbonio/docs-connector
 
-FROM eclipse-temurin:21-jdk-alpine
+FROM docker.io/library/eclipse-temurin:21-jdk-alpine
 
 WORKDIR /app
 

--- a/docker/minimal/carbonio-docs-editor/Dockerfile
+++ b/docker/minimal/carbonio-docs-editor/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM docker.io/library/ubuntu:22.04
 
 USER root
 

--- a/docker/minimal/carbonio-storages/Dockerfile
+++ b/docker/minimal/carbonio-storages/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine
+FROM docker.io/library/node:18-alpine
 
 WORKDIR /app
 

--- a/docker/minimal/composed-ui/Dockerfile
+++ b/docker/minimal/composed-ui/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu/nginx:1.18-20.04_beta
+FROM docker.io/ubuntu/nginx:1.18-20.04_beta
 
 USER root
 

--- a/docker/packaging/Dockerfile
+++ b/docker/packaging/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
-FROM alpine:3.22.1 AS prep
+FROM docker.io/library/alpine:3.22.1 AS prep
 WORKDIR /staging
 COPY ../../. .
 
@@ -40,7 +40,7 @@ COPY --from=prep /staging .
 RUN yap build rocky-9 /tmp/staging/
 
 # Final stage
-FROM alpine:3.22.1 AS final
+FROM docker.io/library/alpine:3.22.1 AS final
 WORKDIR /output
 
 COPY --from=ubuntu-focal-builder /tmp/staging/artifacts ./ubuntu-focal/


### PR DESCRIPTION
## Buildah migration

Replacing `docker buildx` with **buildah**, which requires fully-qualified image references.

### Changes
- **Dockerfiles:** fully-qualify base images (e.g. `alpine:3` -> `docker.io/library/alpine:3`). Multi-stage aliases and already-qualified refs untouched.
- **Jenkinsfile:** bump `jenkins-lib-common` to `@2.10.0`.

> Draft - part of org-wide buildah migration.