### PR TITLE
feat: bump carbonio-quarkus-extensions to 1.11.0-1; scope KV migration discovery by package

### DIFF
--- a/THIRDPARTIES
+++ b/THIRDPARTIES
@@ -1,7 +1,7 @@
 AGPL-3.0-only (https://spdx.org/licenses/AGPL-3.0-only.html) applies to:
 
-  Carbonio Quarkus Extensions - Bootstrap Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-bootstrap:1.10.1-1)
-  Carbonio Quarkus Extensions - REST Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-rest:1.10.1-1)
+  Carbonio Quarkus Extensions - Bootstrap Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-bootstrap:1.11.0-1)
+  Carbonio Quarkus Extensions - REST Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-rest:1.11.0-1)
   Carbonio User Management - gRPC SDK (com.zextras.carbonio.user-management:carbonio-user-management-grpc-sdk:1.0.3-dev.24.f9dd5647)
   carbonio-files-sdk (com.zextras.carbonio.files:carbonio-files-sdk:1.0.1)
 

--- a/app/.flattened-pom.xml
+++ b/app/.flattened-pom.xml
@@ -26,7 +26,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
   <properties>
     <quarkus.version>3.34.5</quarkus.version>
-    <carbonio-quarkus-extensions.version>1.10.1-1</carbonio-quarkus-extensions.version>
+    <carbonio-quarkus-extensions.version>1.11.0-1</carbonio-quarkus-extensions.version>
     <assertj.version>3.27.7</assertj.version>
     <mockito.version>5.20.0</mockito.version>
   </properties>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -26,7 +26,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
   <properties>
     <quarkus.version>3.34.5</quarkus.version>
-    <carbonio-quarkus-extensions.version>1.10.1-1</carbonio-quarkus-extensions.version>
+    <carbonio-quarkus-extensions.version>1.11.0-1</carbonio-quarkus-extensions.version>
     <assertj.version>3.27.7</assertj.version>
     <mockito.version>5.20.0</mockito.version>
   </properties>

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -4,6 +4,12 @@
 # Bootstrap: drives Consul KV namespace + /etc/carbonio/docs-connector/config.properties path
 carbonio.service.name=carbonio-docs-connector
 
+# KV config-migration discovery scope (carbonio-quarkus-extensions 1.11.0-1). Only ConfigMigration
+# subclasses in this package are written to META-INF/carbonio-migrations.list at build time.
+# CE ships NO migration classes (it has no DB), so the generated list is intentionally EMPTY here;
+# the property is set for consistency with Advanced and to future-proof the CE build.
+quarkus.carbonio-bootstrap.migrations-package=com.zextras.carbonio.docs_connector.config.migration
+
 # Networking defaults (overridden by /etc/carbonio/docs-connector/config.properties at runtime)
 # 127.78.0.13 is the assigned static IP for docs-connector -- matches legacy Constants.DocsConnector.DEFAULT_HOST.
 networking-config.carbonio.service.host=127.78.0.13


### PR DESCRIPTION
## What

Bumps `carbonio-quarkus-extensions` to **1.11.0-1** and adopts the new build-time package-scoped KV-migration discovery.

## Changes

- `app/pom.xml`: `carbonio-quarkus-extensions.version` `1.10.1-1` → `1.11.0-1` (`.flattened-pom.xml` synced accordingly — it is tracked in this repo).
- `app/src/main/resources/application.properties`: add `quarkus.carbonio-bootstrap.migrations-package=com.zextras.carbonio.docs_connector.config.migration`.

## Why

`carbonio-quarkus-extensions` 1.11.0-1 changes how KV config migrations are discovered: a build-time package filter (`quarkus.carbonio-bootstrap.migrations-package`) scopes discovery to a single package, keeping each edition's migrations isolated (the Advanced edition maintains its own migration package). This CE edition has **no** `ConfigMigration` classes (it has no database; its only KV, `max-file-size-in-mb/*`, is unchanged across the Quarkus migration and needs no migration), so the generated migration list is intentionally empty — the config is set for consistency and future-proofing across the CE/Advanced pair.

## Backward compatibility

No behavior change: CE has no migrations, and the classloader hardening in 1.11.0-1 is transparent. The only KV keys CE reads (`carbonio-docs-connector/max-file-size-in-mb/{document,presentation,spreadsheet}`) are unaffected.

## Testing

- `mvn clean package` green; **98 unit tests pass, 0 skipped** (against the real published `1.11.0-1`).
- Generated `META-INF/carbonio-migrations.list` is empty and `--setup` prints `Config migration: no migrations found.` — correct for CE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
