### PR TITLE
chore(deps): regenerate THIRDPARTIES for bumped SDK versions

### DIFF
--- a/THIRDPARTIES
+++ b/THIRDPARTIES
@@ -2,8 +2,8 @@ AGPL-3.0-only (https://spdx.org/licenses/AGPL-3.0-only.html) applies to:
 
   Carbonio Quarkus Extensions - Bootstrap Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-bootstrap:1.11.2-1)
   Carbonio Quarkus Extensions - REST Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-rest:1.11.2-1)
-  Carbonio User Management - gRPC SDK (com.zextras.carbonio.user-management:carbonio-user-management-grpc-sdk:1.0.3-dev.24.f9dd5647)
-  carbonio-files-sdk (com.zextras.carbonio.files:carbonio-files-sdk:1.0.1)
+  Carbonio User Management - gRPC SDK (com.zextras.carbonio.user-management:carbonio-user-management-grpc-sdk:1.2.2-1)
+  carbonio-files-sdk (com.zextras.carbonio.files:carbonio-files-sdk:1.1.0-1)
 
 Apache-2.0 (https://spdx.org/licenses/Apache-2.0.html) applies to:
 


### PR DESCRIPTION
Regenerates THIRDPARTIES to match the SDK versions bumped in #158 (grpc-sdk 1.2.2-1, files-sdk 1.1.0-1). The devel release build (#75) failed the Verify Generated Files gate on the stale file. Verified locally: regenerated THIRDPARTIES matches the CI license-plugin output (diff is empty).