### PR TITLE
chore(packaging): migrate yap build images to v2.4

### DIFF
--- a/docker/packaging/Dockerfile
+++ b/docker/packaging/Dockerfile
@@ -9,6 +9,7 @@ COPY ../../. .
 RUN mkdir -p package && \
     cp ./app/target/*-runner package/carbonio-docs-connector-ce-runner 2>/dev/null
 
+# yap-ubuntu-focal has no v2 image upstream; kept on 1.x intentionally
 # Stage Ubuntu 20.04 (Focal)
 FROM docker.io/m0rf30/yap-ubuntu-focal:1.55 AS ubuntu-focal-builder
 WORKDIR /tmp/staging
@@ -16,25 +17,29 @@ COPY --from=prep /staging .
 RUN yap build ubuntu-focal /tmp/staging/
 
 # Stage Ubuntu 22.04 (Jammy)
-FROM docker.io/m0rf30/yap-ubuntu-jammy:1.55 AS ubuntu-jammy-builder
+FROM docker.io/m0rf30/yap-ubuntu-jammy:2.4 AS ubuntu-jammy-builder
+USER root
 WORKDIR /tmp/staging
 COPY --from=prep /staging .
 RUN yap build ubuntu-jammy /tmp/staging/
 
 # Stage Ubuntu 24.04 (Noble)
-FROM docker.io/m0rf30/yap-ubuntu-noble:1.55 AS ubuntu-noble-builder
+FROM docker.io/m0rf30/yap-ubuntu-noble:2.4 AS ubuntu-noble-builder
+USER root
 WORKDIR /tmp/staging
 COPY --from=prep /staging .
 RUN yap build ubuntu-noble /tmp/staging/
 
 # Stage RHEL/Rocky 8
-FROM docker.io/m0rf30/yap-rocky-8:1.55 AS rocky-8-builder
+FROM docker.io/m0rf30/yap-rocky-8:2.4 AS rocky-8-builder
+USER root
 WORKDIR /tmp/staging
 COPY --from=prep /staging .
 RUN yap build rocky-8 /tmp/staging/
 
 # Stage RHEL/Rocky 9
-FROM docker.io/m0rf30/yap-rocky-9:1.55 AS rocky-9-builder
+FROM docker.io/m0rf30/yap-rocky-9:2.4 AS rocky-9-builder
+USER root
 WORKDIR /tmp/staging
 COPY --from=prep /staging .
 RUN yap build rocky-9 /tmp/staging/


### PR DESCRIPTION
## Summary
- Migrate all yap build-stage base images (`ubuntu-jammy`, `ubuntu-noble`, `rocky-8`, `rocky-9`) from `1.55` to `2.4`.
- `2.x` images run as non-root by default, which breaks yap's `fakeroot` `package()` step (`op=RunScriptInFakeroot`); add `USER root` immediately after each of those `FROM ... AS <stage>` lines to restore it.
- `ubuntu-focal` has no `2.x` image published upstream (`docker manifest inspect docker.io/m0rf30/yap-ubuntu-focal:2.4` → `no such manifest`), so it stays pinned on `1.55` with an explanatory comment.

## Why
Renovate opens straight `1.x -> 2.4` tag-swap PRs for these images; merging them as-is breaks the packaging build because yap's fakeroot package step can't run under a non-root user in the v2 images. This PR does the migration properly (tag bump + `USER root`) instead of a bare tag swap.

## Validation
- `docker manifest inspect` confirms `yap-ubuntu-jammy:2.4`, `yap-ubuntu-noble:2.4`, `yap-rocky-8:2.4`, `yap-rocky-9:2.4` all resolve upstream, and `yap-ubuntu-focal:2.4` does not (404 "no such manifest").
- This is a full Quarkus **native** repo, so a local end-to-end packaging build is slow; instead of building here, I validated the identical Dockerfile pattern (tag bump + `USER root`) end-to-end on `carbonio-user-management` (a sibling repo with the same yap packaging layout, JVM build so it's fast to iterate on):
  - Ran the full multi-stage `docker build` there for all 5 distros (focal still on `1.55`, jammy/noble/rocky-8/rocky-9 on `2.4` + `USER root`) — all 5 stages built successfully and produced valid, installable `.deb`/`.rpm` packages (verified via `dpkg-deb -I`/`-c` and control-file inspection).
  - Extracted and `md5sum`-compared the package payloads: the `2.4`-built jammy/noble packages are **byte-for-byte identical** to the `1.55`-built focal baseline for every file except two systemd units that already differ per-distro for unrelated reasons (legacy vs. non-legacy `.service` templates selected by the existing PKGBUILD logic, present before this change).
  - This confirms the `USER root` fix produces package output equivalent to the pre-migration `1.x` build, with no content regression from the base-image bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
