### PR TITLE
chore(renovate): pin ubuntu base image to 24.04, block OS major bumps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -31,6 +31,21 @@
       ],
       "matchCurrentValue": "/^dt3-pipeline$/",
       "enabled": false
+    },
+    {
+      "description": "Keep ubuntu Docker base images on the 24.04 (noble) LTS line; do not auto-bump the OS major (the runtime image runs the native binary directly against glibc). Bump manually when there is a concrete driver.",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "ubuntu",
+        "docker.io/library/ubuntu"
+      ],
+      "matchCurrentValue": "/^(noble|24\\.04)/",
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds a local Renovate `packageRule` in `.github/renovate.json` that disables major-version updates for the `ubuntu` Docker base image, keeping it pinned to the 24.04 (noble) LTS line.
- The runtime image runs the native binary directly against glibc, so an OS major bump (e.g. noble -> 26.04) is not a drop-in change; those Renovate PRs were previously closed as unwanted.
- Digest and patch-level refreshes for the ubuntu base image are unaffected; only `major` update types are disabled by this rule.

## Test plan
- [x] `jq . .github/renovate.json` parses successfully
- [x] Diff reviewed to confirm existing `packageRules` entries (patch/minor grouping, jenkins-lib-common override) are untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)