### PR TITLE
fix(native): use quarkus-caffeine extension for GraalVM-safe token cache

### DIFF
--- a/THIRDPARTIES
+++ b/THIRDPARTIES
@@ -72,6 +72,7 @@ Apache-2.0 (https://spdx.org/licenses/Apache-2.0.html) applies to:
   Quarkus - ArC - Runtime (io.quarkus:quarkus-arc:3.37.2)
   Quarkus - Bootstrap - Classloader common utilities (io.quarkus:quarkus-classloader-commons:3.37.2)
   Quarkus - Bootstrap - Runner (io.quarkus:quarkus-bootstrap-runner:3.37.2)
+  Quarkus - Caffeine - Runtime (io.quarkus:quarkus-caffeine:3.37.2)
   Quarkus - Core - Runtime (io.quarkus:quarkus-core:3.37.2)
   Quarkus - Credentials - Runtime (io.quarkus:quarkus-credentials:3.37.2)
   Quarkus - Development mode - SPI (io.quarkus:quarkus-development-mode-spi:3.37.2)

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -70,10 +70,10 @@ SPDX-License-Identifier: AGPL-3.0-only
       <version>${carbonio-files-sdk.version}</version>
     </dependency>
 
-    <!-- Caffeine: used by token cache (CacheManager) -->
+    <!-- Quarkus extension, not raw caffeine: registers Caffeine's reflectively-loaded cache impl classes for GraalVM native -->
     <dependency>
-      <groupId>com.github.ben-manes.caffeine</groupId>
-      <artifactId>caffeine</artifactId>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-caffeine</artifactId>
     </dependency>
 
     <!-- Consul client: needed for getDocsEditorInstanceIds() health query -->

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,6 @@ SPDX-License-Identifier: AGPL-3.0-only
 
   <properties>
     <assertj.version>3.27.7</assertj.version>
-    <caffeine.version>3.2.3</caffeine.version>
     <carbonio-files-sdk.version>1.1.0-1</carbonio-files-sdk.version>
 
     <maven-compiler.version>3.13.0</maven-compiler.version>


### PR DESCRIPTION
## Problem

The native (GraalVM) integration lane is **red**: `DocsConnectorCeIT` fails **8/23** when run against the native binary, while JVM mode is green.

Root cause — the token cache in `CacheManager`:

```java
tokenCache = Caffeine.newBuilder().expireAfterWrite(...).build();
```

Caffeine selects its bounded-cache implementation class **by name at runtime** via `Class.forName("com.github.benmanes.caffeine.cache." + code)` (here `SSW` = Strong keys / Strong values / expireAfter**W**rite). The raw `com.github.ben-manes.caffeine:caffeine` dependency does **not** register those generated classes for reflection, so GraalVM strips them and every WOPI / `/files/open/*` request that touches the cache fails at runtime:

```
java.lang.IllegalStateException: SSW
  Caused by: java.lang.ClassNotFoundException: com.github.benmanes.caffeine.cache.SSW
```

## Fix

Swap the raw library for the Quarkus extension **`io.quarkus:quarkus-caffeine`**, which brings caffeine transitively (version aligned via `quarkus-bom`) and registers the generated cache classes for native reflection. Also drops the now-unused `caffeine.version` root property. Total diff: 3 lines.

## Verification

Reproduced the CI native flow locally (two-step, `march=compatibility`, mandrel `jdk-25` container builder):

| | Before | After |
|---|---|---|
| Native build | ✅ | ✅ |
| Native IT (`DocsConnectorCeIT`) | ❌ 23 run, **8 failures** | ✅ 23 run, **0 failures** |

Advanced (`carbonio-docs-connector`) is unaffected — it has no Caffeine cache (DB-backed token persistence) and its native IT is already green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)