### PR TITLE
ci: use standard conventionalcommits release rules

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -6,22 +6,7 @@
     [
       "@semantic-release/commit-analyzer",
       {
-        "preset": "conventionalcommits",
-        "releaseRules": [
-          {"type": "feat", "release": "minor"},
-          {"type": "fix", "release": "patch"},
-          {"type": "docs", "release": "patch"},
-          {"type": "style", "release": "patch"},
-          {"type": "refactor", "release": "patch"},
-          {"type": "perf", "release": "patch"},
-          {"type": "test", "release": "patch"},
-          {"type": "build", "release": "patch"},
-          {"type": "ci", "release": "patch"},
-          {"type": "chore", "scope": "release", "release": false},
-          {"type": "chore", "release": "patch"},
-          {"type": "revert", "release": "patch"},
-          {"breaking": true, "release": "major"}
-        ]
+        "preset": "conventionalcommits"
       }
     ],
     [


### PR DESCRIPTION
Removes the custom `releaseRules` from `.releaserc.json` so semantic-release uses the default `conventionalcommits` preset — consistent with carbonio-tasks-ce and the intended convention (only fix/feat/breaking trigger releases; chore/ci do not).

Note: does not itself trigger a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)