### PR TITLE
refactor(native): drop unused com.orbitz consul-client from CE

### DIFF
--- a/THIRDPARTIES
+++ b/THIRDPARTIES
@@ -98,8 +98,6 @@ List of third-party dependencies grouped by their license type.
 
         * Apache Commons Codec (commons-codec:commons-codec:1.22.0 - https://commons.apache.org/proper/commons-codec/)
         * Apache Commons IO (commons-io:commons-io:2.22.0 - https://commons.apache.org/proper/commons-io/)
-        * Apache Commons Lang (org.apache.commons:commons-lang3:3.20.0 - https://commons.apache.org/proper/commons-lang/)
-        * Kotlin Stdlib (org.jetbrains.kotlin:kotlin-stdlib:2.4.0 - https://kotlinlang.org/)
 
     BSD-2-Clause:
 
@@ -177,16 +175,11 @@ List of third-party dependencies grouped by their license type.
     The Apache License, Version 2.0:
 
         * JSpecify annotations (org.jspecify:jspecify:1.0.0 - http://jspecify.org/)
-        * org.jetbrains.kotlin:kotlin-stdlib-common (org.jetbrains.kotlin:kotlin-stdlib-common:1.4.0 - https://kotlinlang.org/)
 
     The Apache Software License, Version 2.0:
 
-        * consul-client (com.orbitz.consul:consul-client:1.5.3 - http://maven.apache.org)
-        * Converter: Jackson (com.squareup.retrofit2:converter-jackson:2.9.0 - https://github.com/square/retrofit)
-        * FindBugs-jsr305 (com.google.code.findbugs:jsr305:3.0.2 - http://findbugs.sourceforge.net/)
         * Google Guice - Core Library (com.google.inject:guice:5.0.1 - https://github.com/google/guice/guice)
         * Guava InternalFutureFailureAccess and InternalFutures (com.google.guava:failureaccess:1.0.1 - https://github.com/google/guava/failureaccess)
-        * Jackson datatype: Guava (com.fasterxml.jackson.datatype:jackson-datatype-guava:2.22.0 - https://github.com/FasterXML/jackson-datatypes-collections)
         * Jackson datatype: jdk8 (com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.22.0 - https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jdk8)
         * Jackson datatype: JSR310 (com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.22.0 - https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jsr310)
         * Jackson-annotations (com.fasterxml.jackson.core:jackson-annotations:2.22 - https://github.com/FasterXML/jackson)
@@ -196,10 +189,7 @@ List of third-party dependencies grouped by their license type.
         * Jackson-module-parameter-names (com.fasterxml.jackson.module:jackson-module-parameter-names:2.22.0 - https://github.com/FasterXML/jackson-modules-java8/jackson-module-parameter-names)
         * Jakarta Dependency Injection (jakarta.inject:jakarta.inject-api:2.0.1 - https://github.com/eclipse-ee4j/injection-api)
         * javax.inject (javax.inject:javax.inject:1 - http://code.google.com/p/atinject/)
-        * JetBrains Java Annotations (org.jetbrains:annotations:26.1.0 - https://github.com/JetBrains/java-annotations)
         * Netty/TomcatNative [OpenSSL - Classes] (io.netty:netty-tcnative-classes:2.0.77.Final - https://github.com/netty/netty-tcnative/netty-tcnative-classes/)
-        * okhttp (com.squareup.okhttp3:okhttp:4.9.0 - https://square.github.io/okhttp/)
-        * Okio (com.squareup.okio:okio:2.8.0 - https://github.com/square/okio/)
         * Quarkus - ArC - Runtime (io.quarkus:quarkus-arc:3.37.2 - https://github.com/quarkusio/quarkus)
         * Quarkus - Caffeine - Runtime (io.quarkus:quarkus-caffeine:3.37.2 - https://github.com/quarkusio/quarkus)
         * Quarkus - Core - Runtime (io.quarkus:quarkus-core:3.37.2 - https://github.com/quarkusio/quarkus)
@@ -227,7 +217,6 @@ List of third-party dependencies grouped by their license type.
         * Quarkus - Vert.x Late Bound MDC Provider (io.quarkus:quarkus-vertx-latebound-mdc-provider:3.37.2 - https://github.com/quarkusio/quarkus)
         * Quarkus - Virtual Threads - Runtime (io.quarkus:quarkus-virtual-threads:3.37.2 - https://github.com/quarkusio/quarkus)
         * Quarkus Security API (io.quarkus.security:quarkus-security:2.3.2 - http://www.jboss.org)
-        * Retrofit (com.squareup.retrofit2:retrofit:2.9.0 - https://github.com/square/retrofit)
         * SmallRye Context Propagation: API (io.smallrye:smallrye-context-propagation-api:2.3.0 - https://github.com/smallrye/smallrye-context-propagation)
         * SmallRye Context Propagation: Core (io.smallrye:smallrye-context-propagation:2.3.0 - https://github.com/smallrye/smallrye-context-propagation)
         * SmallRye Context Propagation: Storage (io.smallrye:smallrye-context-propagation-storage:2.3.0 - https://github.com/smallrye/smallrye-context-propagation)

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -76,14 +76,6 @@ SPDX-License-Identifier: AGPL-3.0-only
       <artifactId>quarkus-caffeine</artifactId>
     </dependency>
 
-    <!-- Consul client: needed for getDocsEditorInstanceIds() health query -->
-    <!-- Bootstrap extension does NOT expose a Consul healthClient bean (Q2 confirmed) -->
-    <dependency>
-      <groupId>com.orbitz.consul</groupId>
-      <artifactId>consul-client</artifactId>
-      <version>1.5.3</version>
-    </dependency>
-
     <!-- Bean validation (jakarta.validation annotations on InsertFile etc.) -->
     <dependency>
       <groupId>io.quarkus</groupId>


### PR DESCRIPTION
## What
Removes the unused `com.orbitz.consul:consul-client` dependency from CE and regenerates `THIRDPARTIES`.

## Why
Nothing in docs-connector imports `com.orbitz.*` — neither CE nor Advanced. Advanced's `AdvancedDocsEditorInstanceSelector` hand-rolls its Consul `/v1/health` query with `java.net.http` + Jackson precisely because com.orbitz's Retrofit dynamic proxies are not native-safe. CE was declaring the dependency (and Advanced inheriting it transitively) for nothing — it only added dead, native-unsafe classes to CE's native image. `THIRDPARTIES` regenerated via `.ci/thirdparties/generate-thirdparties.sh`. Advanced needs no change: it loses the harmless transitive once this ships.

## Verified locally
`mvn -Pnative -Dquarkus.native.container-build=true -Dskip.integration.tests=false verify` → **DocsConnectorCeIT 23/23 green** against the native binary without the dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
