### PR TITLE
fix(deps): bump carbonio-quarkus-extensions to 1.14.0-1

### DIFF
--- a/THIRDPARTIES
+++ b/THIRDPARTIES
@@ -3,8 +3,8 @@ List of third-party dependencies grouped by their license type.
 
     AGPL-3.0-only:
 
-        * Carbonio Quarkus Extensions - Bootstrap Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-bootstrap:1.13.0-1 - no url defined)
-        * Carbonio Quarkus Extensions - REST Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-rest:1.13.0-1 - no url defined)
+        * Carbonio Quarkus Extensions - Bootstrap Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-bootstrap:1.14.0-1 - no url defined)
+        * Carbonio Quarkus Extensions - REST Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-rest:1.14.0-1 - no url defined)
         * Carbonio User Management - REST SDK (com.zextras.carbonio.user-management:carbonio-user-management-rest-sdk:1.3.0-1 - no url defined)
         * carbonio-files-sdk (com.zextras.carbonio.files:carbonio-files-sdk:1.1.0-1 - no url defined)
 

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -26,7 +26,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
   <properties>
     <quarkus.version>3.37.2</quarkus.version>
-    <carbonio-quarkus-extensions.version>1.13.0-1</carbonio-quarkus-extensions.version>
+    <carbonio-quarkus-extensions.version>1.14.0-1</carbonio-quarkus-extensions.version>
     <assertj.version>3.27.7</assertj.version>
     <mockito.version>5.23.0</mockito.version>
   </properties>


### PR DESCRIPTION
Consume the foreground (on-acquire) DB connection validation default from carbonio-quarkus-extensions 1.14.0-1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)